### PR TITLE
fix(ui): update route IDs for non-nested validator routes

### DIFF
--- a/ui/src/routeTree.gen.ts
+++ b/ui/src/routeTree.gen.ts
@@ -19,21 +19,25 @@ import { Route as ValidatorsValidatorIdImport } from './routes/validators_.$vali
 // Create/Update Routes
 
 const ValidatorsRoute = ValidatorsImport.update({
+  id: '/validators',
   path: '/validators',
   getParentRoute: () => rootRoute,
 } as any)
 
 const AddRoute = AddImport.update({
+  id: '/add',
   path: '/add',
   getParentRoute: () => rootRoute,
 } as any)
 
 const IndexRoute = IndexImport.update({
+  id: '/',
   path: '/',
   getParentRoute: () => rootRoute,
 } as any)
 
 const ValidatorsValidatorIdRoute = ValidatorsValidatorIdImport.update({
+  id: '/validators_/$validatorId',
   path: '/validators/$validatorId',
   getParentRoute: () => rootRoute,
 } as any)
@@ -63,8 +67,8 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ValidatorsImport
       parentRoute: typeof rootRoute
     }
-    '/validators/$validatorId': {
-      id: '/validators/$validatorId'
+    '/validators_/$validatorId': {
+      id: '/validators_/$validatorId'
       path: '/validators/$validatorId'
       fullPath: '/validators/$validatorId'
       preLoaderRoute: typeof ValidatorsValidatorIdImport
@@ -94,7 +98,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/add': typeof AddRoute
   '/validators': typeof ValidatorsRoute
-  '/validators/$validatorId': typeof ValidatorsValidatorIdRoute
+  '/validators_/$validatorId': typeof ValidatorsValidatorIdRoute
 }
 
 export interface FileRouteTypes {
@@ -102,7 +106,7 @@ export interface FileRouteTypes {
   fullPaths: '/' | '/add' | '/validators' | '/validators/$validatorId'
   fileRoutesByTo: FileRoutesByTo
   to: '/' | '/add' | '/validators' | '/validators/$validatorId'
-  id: '__root__' | '/' | '/add' | '/validators' | '/validators/$validatorId'
+  id: '__root__' | '/' | '/add' | '/validators' | '/validators_/$validatorId'
   fileRoutesById: FileRoutesById
 }
 
@@ -135,7 +139,7 @@ export const routeTree = rootRoute
         "/",
         "/add",
         "/validators",
-        "/validators/$validatorId"
+        "/validators_/$validatorId"
       ]
     },
     "/": {
@@ -147,7 +151,7 @@ export const routeTree = rootRoute
     "/validators": {
       "filePath": "validators.tsx"
     },
-    "/validators/$validatorId": {
+    "/validators_/$validatorId": {
       "filePath": "validators_.$validatorId.tsx"
     }
   }

--- a/ui/src/routes/validators_.$validatorId.tsx
+++ b/ui/src/routes/validators_.$validatorId.tsx
@@ -1,6 +1,3 @@
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
-import { ErrorComponent, createFileRoute } from '@tanstack/react-router'
-import { useWallet } from '@txnlab/use-wallet-react'
 import { ValidatorNotFoundError } from '@/api/contracts'
 import { constraintsQueryOptions, stakesQueryOptions, validatorQueryOptions } from '@/api/queries'
 import { Loading } from '@/components/Loading'
@@ -8,8 +5,11 @@ import { Meta } from '@/components/Meta'
 import { PageMain } from '@/components/PageMain'
 import { ValidatorDetails } from '@/components/ValidatorDetails'
 import { DetailsHeader } from '@/components/ValidatorDetails/DetailsHeader'
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
+import { ErrorComponent, createFileRoute } from '@tanstack/react-router'
+import { useWallet } from '@txnlab/use-wallet-react'
 
-export const Route = createFileRoute('/validators/$validatorId')({
+export const Route = createFileRoute('/validators_/$validatorId')({
   beforeLoad: () => {
     return {
       validatorQueryOptions,

--- a/ui/src/routes/validators_.$validatorId.tsx
+++ b/ui/src/routes/validators_.$validatorId.tsx
@@ -1,3 +1,6 @@
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
+import { ErrorComponent, createFileRoute } from '@tanstack/react-router'
+import { useWallet } from '@txnlab/use-wallet-react'
 import { ValidatorNotFoundError } from '@/api/contracts'
 import { constraintsQueryOptions, stakesQueryOptions, validatorQueryOptions } from '@/api/queries'
 import { Loading } from '@/components/Loading'
@@ -5,9 +8,6 @@ import { Meta } from '@/components/Meta'
 import { PageMain } from '@/components/PageMain'
 import { ValidatorDetails } from '@/components/ValidatorDetails'
 import { DetailsHeader } from '@/components/ValidatorDetails/DetailsHeader'
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
-import { ErrorComponent, createFileRoute } from '@tanstack/react-router'
-import { useWallet } from '@txnlab/use-wallet-react'
 
 export const Route = createFileRoute('/validators_/$validatorId')({
   beforeLoad: () => {


### PR DESCRIPTION
## Description

This PR updates the route IDs in the auto-generated router files to match Tanstack Router v1.63.2's updated syntax for non-nested routes. These changes were automatically generated when running the UI's `dev` script after upgrading from v1.56.5.

## Details
- Add explicit route `id` fields to match new Tanstack Router requirements
- Update validator detail route ID from `/validators/$validatorId` to `/validators_/$validatorId` to follow non-nested route syntax
- Maintain existing route paths and functionality