### PR TITLE
fix(vscode): remove auto-organize imports setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,6 @@
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit",
-    "source.organizeImports": "explicit"
-  },
+    "source.fixAll.eslint": "explicit"
+  }
 }


### PR DESCRIPTION
## Description
Removes the automatic import organization on save from VS Code workspace settings to preserve existing import orders and prevent unnecessary changes.

## Details
- Remove `source.organizeImports` from `editor.codeActionsOnSave`
- Maintain existing ESLint and Prettier formatting settings
- Prevents unwanted import reordering that pollutes git diffs with non-functional changes