### PR TITLE
feat(ui): optional extra footer item

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ This section provides instructions for running the protocol and UI in a local Al
 	pnpm run dev:testnet
 	```
 
+## Documentation
+- The documentation is currently available online at https://txnlab.gitbook.io/reti-open-pooling
+- The content is synced with the docs/gitbook branch of this repo inside the ./docs directory.
+  - The changes in that branch should periodically be merged into main but the docs/gitbook branch is the source of truth for the public docs site currently hosted at: https://txnlab.gitbook.io/reti-open-pooling
+
 ## Additional Resources
 
 - **TEALScript Contracts**: Explore the smart contracts that power the protocol. [Read more](./contracts/README.md)

--- a/ui/src/components/Footer.tsx
+++ b/ui/src/components/Footer.tsx
@@ -30,6 +30,22 @@ const navigation = [
   },
 ]
 
+export function FooterExtraItem() {
+  return (
+    <>
+      <span className="mx-1 opacity-50">|</span>{' '}
+      <a
+        href={import.meta.env.VITE_FOOTER_EXTRA_ITEM_HREF}
+        className="link hover:text-foreground"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {import.meta.env.VITE_FOOTER_EXTRA_ITEM}
+      </a>
+    </>
+  )
+}
+
 export function Footer() {
   return (
     <footer className="bg-background" aria-labelledby="footer-heading">
@@ -62,6 +78,7 @@ export function Footer() {
             >
               TxnLab/reti
             </a>
+            {import.meta.env.VITE_FOOTER_EXTRA_ITEM && FooterExtraItem()}
           </p>
         </div>
       </div>

--- a/ui/src/components/Footer.tsx
+++ b/ui/src/components/Footer.tsx
@@ -69,15 +69,7 @@ export function Footer() {
         </div>
         <div className="mt-8 md:order-1 md:mt-0">
           <p className="text-center text-sm leading-5 text-stone-600 dark:text-stone-400">
-            Réti Pooling v{__APP_VERSION__} <span className="mx-1 opacity-50">|</span>{' '}
-            <a
-              href="https://github.com/algorandfoundation/reti"
-              className="link hover:text-foreground"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              TxnLab/reti
-            </a>
+            Réti Pooling v{__APP_VERSION__}
             {import.meta.env.VITE_FOOTER_EXTRA_ITEM && FooterExtraItem()}
           </p>
         </div>

--- a/ui/src/vite-env.d.ts
+++ b/ui/src/vite-env.d.ts
@@ -17,6 +17,9 @@ interface ImportMetaEnv {
   readonly VITE_KMD_PORT: string
   readonly VITE_KMD_PASSWORD: string
   readonly VITE_KMD_WALLET: string
+
+  readonly VITE_FOOTER_EXTRA_ITEM: string
+  readonly VITE_FOOTER_EXTRA_ITEM_HREF: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
### Description

This PR adds an optional footer item with URL based on the build time env vars. 

### Details

Two new env vars :
* VITE_FOOTER_EXTRA_ITEM - item label
* VITE_FOOTER_EXTRA_ITEM_HREF - item URL 

When VITE_FOOTER_EXTRA_ITEM env var is defined at build time, an extra item is added to the dashboard footer.

Example:

```bash
VITE_FOOTER_EXTRA_ITEM="Nodely DISCLAIMER"
VITE_FOOTER_EXTRA_ITEM_HREF=https://nodely.io/docs/public/reti/
```