### PR TITLE
fix(ui): increase default transaction validity window

### DIFF
--- a/ui/src/api/clients.ts
+++ b/ui/src/api/clients.ts
@@ -8,7 +8,7 @@ import { getAlgodConfigFromViteEnvironment } from '@/utils/network/getAlgoClient
 import { AlgorandClient } from '@algorandfoundation/algokit-utils'
 
 const algodConfig = getAlgodConfigFromViteEnvironment()
-const algorandClient = AlgorandClient.fromConfig({ algodConfig: algodConfig })
+const algorandClient = AlgorandClient.fromConfig({ algodConfig }).setDefaultValidityWindow(200)
 
 const RETI_APP_ID = BigInt(getRetiAppIdFromViteEnvironment())
 


### PR DESCRIPTION
## Description

This PR increases the default transaction validity window to address user-reported issues with transaction signing timeouts, particularly when using hardware wallets like Ledger.

## Details
- Modified `algorandClient` configuration to set default validity window to 200 rounds