### PR TITLE
fix(ui): prevent incorrect update notifications

### DIFF
--- a/ui/src/hooks/useCheckForUpdates.ts
+++ b/ui/src/hooks/useCheckForUpdates.ts
@@ -9,11 +9,30 @@ export function useCheckForUpdates() {
 
     const checkForUpdates = async () => {
       try {
-        const response = await fetch('/version.json')
+        const response = await fetch(`/version.json?_=${Date.now()}`, {
+          cache: 'no-store',
+          headers: {
+            'Cache-Control': 'no-cache, no-store, must-revalidate',
+            Pragma: 'no-cache',
+            Expires: '0',
+          },
+        })
+
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`)
+        }
+
         const data = await response.json()
         const deployedVersion = data.version
 
         if (deployedVersion !== __APP_VERSION__) {
+          // eslint-disable-next-line no-console
+          console.log('Version mismatch detected:', {
+            current: __APP_VERSION__,
+            deployed: deployedVersion,
+            timestamp: new Date().toISOString(),
+          })
+
           toast(`A new version is available! v${deployedVersion}`, {
             description: 'Click the Reload button to update the app.',
             action: {
@@ -29,15 +48,15 @@ export function useCheckForUpdates() {
       }
     }
 
-    const delay = Number(import.meta.env.VITE_UPDATE_CHECK_INTERVAL || 1000 * 60)
+    checkForUpdates()
 
+    const delay = Number(import.meta.env.VITE_UPDATE_CHECK_INTERVAL || 1000 * 60)
     if (Number.isNaN(delay)) {
       console.error('Invalid update check interval:', import.meta.env.VITE_UPDATE_CHECK_INTERVAL)
       return
     }
 
     const interval = setInterval(checkForUpdates, delay)
-
     return () => clearInterval(interval)
   }, [])
 }

--- a/ui/src/hooks/useCheckForUpdates.ts
+++ b/ui/src/hooks/useCheckForUpdates.ts
@@ -1,6 +1,24 @@
 import * as React from 'react'
 import { toast } from 'sonner'
 
+// Helper function to compare versions
+function isNewerVersion(current: string, deployed: string): boolean {
+  // Remove 'v' prefix if present
+  const cleanCurrent = current.replace(/^v/, '')
+  const cleanDeployed = deployed.replace(/^v/, '')
+
+  const currentParts = cleanCurrent.split('.').map(Number)
+  const deployedParts = cleanDeployed.split('.').map(Number)
+
+  // Compare major.minor.patch
+  for (let i = 0; i < 3; i++) {
+    if (deployedParts[i] > currentParts[i]) return true
+    if (deployedParts[i] < currentParts[i]) return false
+  }
+
+  return false
+}
+
 export function useCheckForUpdates() {
   React.useEffect(() => {
     if (import.meta.env.MODE !== 'production') {
@@ -25,9 +43,10 @@ export function useCheckForUpdates() {
         const data = await response.json()
         const deployedVersion = data.version
 
-        if (deployedVersion !== __APP_VERSION__) {
+        // Only show toast if deployed version is newer
+        if (isNewerVersion(__APP_VERSION__, deployedVersion)) {
           // eslint-disable-next-line no-console
-          console.log('Version mismatch detected:', {
+          console.log('New version detected:', {
             current: __APP_VERSION__,
             deployed: deployedVersion,
             timestamp: new Date().toISOString(),

--- a/ui/vite.config.mjs
+++ b/ui/vite.config.mjs
@@ -20,11 +20,18 @@ const replaceVersionPlugin = () => {
       outDir = config.build.outDir
     },
     generateBundle() {
-      const filePath = path.resolve(__dirname, 'public/version.json')
-      const content = fs.readFileSync(filePath, 'utf-8')
-      const updatedContent = content.replace('__APP_VERSION__', version)
-      const newFilePath = path.resolve(outDir, 'version.json')
-      fs.writeFileSync(newFilePath, updatedContent, 'utf-8')
+      try {
+        const filePath = path.resolve(__dirname, 'public/version.json')
+        if (!fs.existsSync(filePath)) {
+          throw new Error(`version.json not found at ${filePath}`)
+        }
+        const content = fs.readFileSync(filePath, 'utf-8')
+        const updatedContent = content.replace('__APP_VERSION__', version)
+        const newFilePath = path.resolve(outDir, 'version.json')
+        fs.writeFileSync(newFilePath, updatedContent, 'utf-8')
+      } catch (error) {
+        console.error('Failed to replace version in version.json file:', error)
+      }
     },
   }
 }


### PR DESCRIPTION
## Description

This PR enhances the version check system to prevent incorrect update notifications and adds better caching prevention. Previously, users could sometimes see update notifications for older versions due to (suspected) caching issues and imprecise version comparison.

## Details
- Add `isNewerVersion` helper to properly compare semver versions
- Add cache-busting query parameter and headers to version check request
- Only show update notification when deployed version is newer than current version
- Add detailed logging to help diagnose version comparison issues
- Improve error handling for failed version checks