### PR TITLE
fix(ui): strengthen version check cache prevention

### DIFF
--- a/ui/src/hooks/useCheckForUpdates.ts
+++ b/ui/src/hooks/useCheckForUpdates.ts
@@ -28,11 +28,12 @@ export function useCheckForUpdates() {
     const checkForUpdates = async () => {
       try {
         const response = await fetch(`/version.json?_=${Date.now()}`, {
-          cache: 'no-store',
+          cache: 'no-cache',
           headers: {
-            'Cache-Control': 'no-cache, no-store, must-revalidate',
+            'Cache-Control': 'no-cache',
             Pragma: 'no-cache',
-            Expires: '0',
+            'If-None-Match': '*',
+            'If-Modified-Since': '0',
           },
         })
 


### PR DESCRIPTION
## Description

This PR enhances the version check system with more robust cache prevention headers. While [`v0.12.1` (release)](https://github.com/algorandfoundation/reti/releases/tag/v0.12.1) added initial cache-busting via query parameters, this change implements a more standards-compliant approach using HTTP cache validation headers.

## Details
- Change fetch cache mode to `no-cache` to work better with HTTP caching model
- Add `If-None-Match` and `If-Modified-Since` validation headers
- Maintain existing cache-busting query parameter as additional safeguard
- Allow proper 304 Not Modified responses for better efficiency