### PR TITLE
refactor(ui): remove APY display from validator components

### DIFF
--- a/ui/src/components/ValidatorDetails/StakingDetails.tsx
+++ b/ui/src/components/ValidatorDetails/StakingDetails.tsx
@@ -5,7 +5,7 @@ import { BarList, EventProps, ProgressBar } from '@tremor/react'
 import { useWallet } from '@txnlab/use-wallet-react'
 import { Ban, Copy, Signpost } from 'lucide-react'
 import * as React from 'react'
-import { nfdLookupQueryOptions, poolApyQueryOptions } from '@/api/queries'
+import { nfdLookupQueryOptions } from '@/api/queries'
 import { AddStakeModal } from '@/components/AddStakeModal'
 import { AlgoDisplayAmount } from '@/components/AlgoDisplayAmount'
 import { ErrorAlert } from '@/components/ErrorAlert'
@@ -25,7 +25,6 @@ import {
 import { UnstakeModal } from '@/components/UnstakeModal'
 import { LinkPoolToNfdModal } from '@/components/ValidatorDetails/LinkPoolToNfdModal'
 import { PoolsChart } from '@/components/ValidatorDetails/PoolsChart'
-import { useBlockTime } from '@/hooks/useBlockTime'
 import { useStakersChartData } from '@/hooks/useStakersChartData'
 import { StakerValidatorData } from '@/interfaces/staking'
 import { Validator } from '@/interfaces/validator'
@@ -77,12 +76,12 @@ export function StakingDetails({ validator, constraints, stakesByValidator }: St
   const selectedPoolInfo = selectedPool === 'all' ? null : poolsInfo[Number(selectedPool)]
 
   // Set poolApyQuery staleTime to epoch length in ms
-  const blockTime = useBlockTime()
-  const staleTime = validator.config.epochRoundLength * blockTime.ms
+  // const blockTime = useBlockTime()
+  // const staleTime = validator.config.epochRoundLength * blockTime.ms
 
   // Fetch APY for selected pool (setting poolAppId to 0 disables query)
-  const poolApyQuery = useQuery(poolApyQueryOptions(selectedPoolInfo?.poolAppId || 0n, staleTime))
-  const selectedPoolApy = poolApyQuery.data
+  // const poolApyQuery = useQuery(poolApyQueryOptions(selectedPoolInfo?.poolAppId || 0n, staleTime))
+  // const selectedPoolApy = poolApyQuery.data
 
   const poolNfdQuery = useQuery(
     nfdLookupQueryOptions(
@@ -259,7 +258,7 @@ export function StakingDetails({ validator, constraints, stakesByValidator }: St
                   {validator.state.numPools}
                 </dd>
               </div>
-              <div className="py-4 grid grid-cols-2 gap-4">
+              {/* <div className="py-4 grid grid-cols-2 gap-4">
                 <dt className="text-sm font-medium leading-6 text-muted-foreground">Avg APY</dt>
                 <dd className="flex items-center gap-x-2 text-sm leading-6">
                   {validator.apy ? (
@@ -268,7 +267,7 @@ export function StakingDetails({ validator, constraints, stakesByValidator }: St
                     <span className="text-muted-foreground">--</span>
                   )}
                 </dd>
-              </div>
+              </div> */}
               <div className="py-4 grid grid-cols-2 gap-4">
                 <dt className="text-sm font-medium leading-6 text-muted-foreground">
                   Total Stakers
@@ -376,7 +375,7 @@ export function StakingDetails({ validator, constraints, stakesByValidator }: St
               </dd>
             </div>
 
-            <div className="py-4 grid grid-cols-2 gap-4">
+            {/* <div className="py-4 grid grid-cols-2 gap-4">
               <dt className="text-sm font-medium leading-6 text-muted-foreground">APY</dt>
               <dd className="flex items-center gap-x-2 text-sm leading-6">
                 {selectedPoolApy ? (
@@ -385,7 +384,7 @@ export function StakingDetails({ validator, constraints, stakesByValidator }: St
                   <span className="text-muted-foreground">--</span>
                 )}
               </dd>
-            </div>
+            </div> */}
 
             <div className="py-4 grid grid-cols-2 gap-4">
               <dt className="text-sm font-medium leading-6 text-muted-foreground">Stakers</dt>

--- a/ui/src/components/ValidatorTable.tsx
+++ b/ui/src/components/ValidatorTable.tsx
@@ -66,7 +66,7 @@ import {
 import { dayjs } from '@/utils/dayjs'
 import { sendRewardTokensToPool, simulateEpoch } from '@/utils/development'
 import { ellipseAddressJsx } from '@/utils/ellipseAddress'
-import { formatAmount, formatAssetAmount } from '@/utils/format'
+import { formatAssetAmount } from '@/utils/format'
 import { globalFilterFn, sunsetFilter } from '@/utils/table'
 import { cn } from '@/utils/ui'
 import { Constraints } from '@/contracts/ValidatorRegistryClient'
@@ -282,15 +282,15 @@ export function ValidatorTable({
         )
       },
     },
-    {
-      id: 'apy',
-      accessorFn: (row) => row.apy,
-      header: ({ column }) => <DataTableColumnHeader column={column} title="APY" />,
-      cell: ({ row }) => {
-        if (!row.original.apy) return <span className="text-muted-foreground">--</span>
-        return <span>{formatAmount(row.original.apy, { precision: 3 })}%</span>
-      },
-    },
+    // {
+    //   id: 'apy',
+    //   accessorFn: (row) => row.apy,
+    //   header: ({ column }) => <DataTableColumnHeader column={column} title="APY" />,
+    //   cell: ({ row }) => {
+    //     if (!row.original.apy) return <span className="text-muted-foreground">--</span>
+    //     return <span>{formatAmount(row.original.apy, { precision: 3 })}%</span>
+    //   },
+    // },
     {
       id: 'reward',
       accessorFn: (row) => row.rewardsBalance,


### PR DESCRIPTION
## Description

This PR temporarily removes APY display functionality from validator-related components due to inconsistent calculations causing misleading information for stakers.

## Details
- Remove APY column from `ValidatorTable` component
- Remove APY display sections from `StakingDetails` component
- Clean up unused APY-related imports and query logic
- Hide APY information until calculation issues can be resolved to prevent misleading staking decisions