### PR TITLE
feat(ui): display NFD names for stakers in validator details

### DIFF
--- a/ui/src/utils/tests/msw/handlers.ts
+++ b/ui/src/utils/tests/msw/handlers.ts
@@ -15,6 +15,8 @@ import { appFixtures } from '@/utils/tests/fixtures/applications'
 import { boxFixtures } from '@/utils/tests/fixtures/boxes'
 import { methodFixtures } from '@/utils/tests/fixtures/methods'
 import { parseBoxName } from '@/utils/tests/utils'
+import { MOCK_ROOT_NFD } from '@/utils/tests/fixtures/nfd'
+import { ACCOUNT_1 } from '@/utils/tests/fixtures/accounts'
 
 const handlers = [
   http.get('http://localhost:4001/v2/blocks/:block', async ({ params, request }) => {
@@ -222,6 +224,36 @@ const handlers = [
       console.error('Error fetching data:', error)
       return HttpResponse.error()
     }
+  }),
+  http.get('http://localhost/nfd/lookup', async ({ request }) => {
+    try {
+      const url = new URL(request.url)
+      const address = url.searchParams.get('address')
+
+      // Return mock NFD data for ACCOUNT_1, null for others
+      if (address === ACCOUNT_1) {
+        return HttpResponse.json({
+          ...MOCK_ROOT_NFD,
+          name: 'account1.algo',
+          owner: ACCOUNT_1,
+        })
+      }
+
+      // Return 404 for addresses without NFDs
+      return new HttpResponse(null, { status: 404 })
+    } catch (error) {
+      console.error('Error handling NFD lookup:', error)
+      return HttpResponse.error()
+    }
+  }),
+  http.options('http://localhost/nfd/lookup', () => {
+    return new HttpResponse(null, {
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, OPTIONS',
+        'Access-Control-Allow-Headers': '*',
+      },
+    })
   }),
 ]
 


### PR DESCRIPTION
## Description

This PR enhances the staker list in validator details by integrating NFD name resolution. When a staker has an associated NFD name, it will be displayed instead of their Algorand address and link to their NFD profile instead of the explorer.

## Details
- Added NFD lookups for all staker addresses using `useQueries`
- Updated display to show NFD names when available, falling back to addresses
- Modified links to point to NFD profiles when NFD names exist
- Maintained existing explorer links for addresses without NFDs
- Added MSW handlers to mock NFD lookup requests in tests
  - Returns mock NFD data for test account
  - Returns 404 for addresses without NFDs
  - Handles CORS preflight requests