### PR TITLE
fix(ui): default to pool 1 view when pools exist

### DIFF
--- a/ui/src/components/ValidatorDetails/StakingDetails.tsx
+++ b/ui/src/components/ValidatorDetails/StakingDetails.tsx
@@ -50,7 +50,9 @@ interface StakingDetailsProps {
 }
 
 export function StakingDetails({ validator, constraints, stakesByValidator }: StakingDetailsProps) {
-  const [selectedPool, setSelectedPool] = React.useState<string>('all')
+  const [selectedPool, setSelectedPool] = React.useState<string>(
+    validator?.pools.length > 0 ? '0' : 'all',
+  )
   const [addStakeValidator, setAddStakeValidator] = React.useState<Validator | null>(null)
   const [unstakeValidator, setUnstakeValidator] = React.useState<Validator | null>(null)
 


### PR DESCRIPTION
## Description

This PR updates the `StakingDetails` component to show Pool 1 by default when a validator has pools, rather than showing the "All Pools" view. The "All Pools" view is only shown by default when a validator has no pools.

## Details
- Changed initial `selectedPool` state to default to Pool 1 when pools exist
- Maintained "All Pools" default for validators with no pools to show empty state