### PR TITLE
fix(ui): fix incorrect reward token assignment in useValidator

### DIFF
--- a/ui/src/hooks/useValidator.ts
+++ b/ui/src/hooks/useValidator.ts
@@ -32,14 +32,18 @@ export function useValidator(validatorId: number): Validator | undefined {
       ],
     })
 
-  // Enrichment queries
-  const [rewardTokenQuery, ...gatingAssetQueries] = useSuspenseQueries({
+  // Reward token query
+  const [rewardTokenQuery] = useSuspenseQueries({
     queries: [
-      // Reward token query
       ...(configQuery.data?.rewardTokenId && configQuery.data.rewardTokenId > 0n
         ? [assetQueryOptions(Number(configQuery.data.rewardTokenId))]
         : []),
-      // Gating asset queries
+    ],
+  })
+
+  // Gating asset queries
+  const gatingAssetQueries = useSuspenseQueries({
+    queries: [
       ...(configQuery.data?.entryGatingType === GatingType.AssetId
         ? configQuery.data.entryGatingAssets
             .filter((id): id is bigint => id > 0n)

--- a/ui/src/hooks/useValidator.ts
+++ b/ui/src/hooks/useValidator.ts
@@ -1,4 +1,4 @@
-import { useQueryClient, useSuspenseQueries } from '@tanstack/react-query'
+import { useQuery, useQueryClient, useSuspenseQueries } from '@tanstack/react-query'
 import algosdk from 'algosdk'
 import * as React from 'react'
 import { createBaseValidator } from '@/api/contracts'
@@ -33,12 +33,9 @@ export function useValidator(validatorId: number): Validator | undefined {
     })
 
   // Reward token query
-  const [rewardTokenQuery] = useSuspenseQueries({
-    queries: [
-      ...(configQuery.data?.rewardTokenId && configQuery.data.rewardTokenId > 0n
-        ? [assetQueryOptions(Number(configQuery.data.rewardTokenId))]
-        : []),
-    ],
+  const rewardTokenQuery = useQuery({
+    ...assetQueryOptions(Number(configQuery.data?.rewardTokenId)),
+    enabled: Boolean(configQuery.data?.rewardTokenId && configQuery.data.rewardTokenId > 0n),
   })
 
   // Gating asset queries
@@ -76,7 +73,7 @@ export function useValidator(validatorId: number): Validator | undefined {
     })
 
     // Add enrichment data
-    if (rewardTokenQuery?.data) {
+    if (rewardTokenQuery.data) {
       baseValidator.rewardToken = rewardTokenQuery.data
     }
 
@@ -104,7 +101,7 @@ export function useValidator(validatorId: number): Validator | undefined {
     stateQuery.data,
     poolsQuery.data,
     nodePoolAssignmentQuery.data,
-    rewardTokenQuery?.data,
+    rewardTokenQuery.data,
     gatingAssetQueries,
     nfdQuery?.data,
     metricsQuery.data,


### PR DESCRIPTION
## Description

This PR fixes a bug in the `useValidator` hook where gating assets were being incorrectly assigned to the `rewardToken` property when no reward token existed. This was caused by array destructuring confusion between reward token and gating asset queries.

## Details
- Separate reward token and gating asset queries into distinct calls
- Replace `useSuspenseQueries` with conditional `useQuery` for reward token fetching
- Maintain existing validation logic for both query types
- Ensure gating assets are correctly assigned to their proper property