### PR TITLE
fix(ui): ensure percentToValidator is rounded to integer

### DIFF
--- a/ui/src/api/contracts.ts
+++ b/ui/src/api/contracts.ts
@@ -259,7 +259,7 @@ export async function addValidator(
     rewardTokenId: BigInt(values.rewardTokenId) ?? 0n,
     rewardPerPayout: BigInt(values.rewardPerPayout) ?? 0n,
     epochRoundLength: Number(values.epochRoundLength),
-    percentToValidator: Number(values.percentToValidator) * 10000,
+    percentToValidator: Math.round(Number(values.percentToValidator) * 10000),
     validatorCommissionAddress: values.validatorCommissionAddress,
     minEntryStake: AlgoAmount.Algos(BigInt(values.minEntryStake)).microAlgos,
     maxAlgoPerPool: 0n,


### PR DESCRIPTION
## Description

This PR fixes an issue in the `addValidator` contract call where floating point precision was causing errors when setting the `percentToValidator` parameter. Valid input values like '4.69' were resulting in floating point imprecision (46900.00000000001) when multiplied by 10000.

## Details
- Added `Math.round()` to ensure clean integer conversion when multiplying `percentToValidator` by 10000
- Maintains existing validation that allows up to 4 decimal places
- Ensures valid inputs like '4.69' are handled correctly in the contract call