### PR TITLE
fix(ui): handle decimal inputs in validator forms

### DIFF
--- a/ui/src/api/contracts.ts
+++ b/ui/src/api/contracts.ts
@@ -261,7 +261,7 @@ export async function addValidator(
     epochRoundLength: Number(values.epochRoundLength),
     percentToValidator: Math.round(Number(values.percentToValidator) * 10000),
     validatorCommissionAddress: values.validatorCommissionAddress,
-    minEntryStake: AlgoAmount.Algos(BigInt(values.minEntryStake)).microAlgos,
+    minEntryStake: AlgoAmount.Algos(Number(values.minEntryStake)).microAlgos,
     maxAlgoPerPool: 0n,
     poolsPerNode: Number(values.poolsPerNode),
     sunsettingOn: 0n,

--- a/ui/src/utils/validation.ts
+++ b/ui/src/utils/validation.ts
@@ -186,7 +186,7 @@ export const validatorSchemas = {
       })
       .refine(
         (val) => {
-          const match = val.match(/^\d+(\.\d{1,6})?$/)
+          const match = val.match(/^(\d*\.?\d{1,6}|\d+)$/)
           return match !== null
         },
         {
@@ -251,7 +251,7 @@ export const rewardTokenRefinement = (
         message: 'Required field',
       })
     } else if (decimals) {
-      const regex = new RegExp(`^\\d+(\\.\\d{1,${Number(decimals)}})?$`)
+      const regex = new RegExp(`^(\\d*\\.?\\d{1,${Number(decimals)}}|\\d+)$`)
 
       if (!regex.test(rewardPerPayout)) {
         ctx.addIssue({


### PR DESCRIPTION
## Description
This PR fixes validation handling for decimal inputs in validator forms, including support for values starting with a point (e.g. `.169`) and proper conversion of decimal values to microAlgos.

## Details
- Update regex pattern in `minEntryStake` validation to accept leading decimal points
- Update regex pattern in `rewardTokenRefinement` validation to handle leading decimal points
- Fix `minEntryStake` conversion to use `Number` instead of `BigInt` to support decimal values