### PR TITLE
fix(ui): convert pool address to string for NFD query key

### DIFF
--- a/ui/src/components/ValidatorDetails/LinkPoolToNfdModal.tsx
+++ b/ui/src/components/ValidatorDetails/LinkPoolToNfdModal.tsx
@@ -110,8 +110,10 @@ export function LinkPoolToNfdModal({
       })
 
       const poolAppAddress = algosdk.getApplicationAddress(poolAppId)
-      // queryClient.invalidateQueries({ queryKey: ['nfd-lookup', poolAppAddress] })
-      queryClient.setQueryData(['nfd-lookup', poolAppAddress, { view: 'thumbnail' }], nfd)
+      queryClient.setQueryData(
+        ['nfd-lookup', poolAppAddress.toString(), { view: 'thumbnail' }],
+        nfd,
+      )
 
       handleOpenChange(false)
     } catch (error) {


### PR DESCRIPTION
## Description

This PR fixes an issue with NFD query keys in `LinkPoolToNfdModal` following the `algosdk` v3 migration: https://github.com/algorandfoundation/reti/pull/330

The fix ensures proper address handling for NFD lookups.

## Details
- Convert `algosdk.Address` object to string when using as query key
- Fix compatibility with `algosdk` v3's new `getApplicationAddress` return type
- Maintain correct NFD lookup functionality for pool linking