### PR TITLE
fix(ui): adjust toast z-index to resolve overlay conflicts

### DIFF
--- a/ui/src/components/ui/sonner.tsx
+++ b/ui/src/components/ui/sonner.tsx
@@ -9,7 +9,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
   return (
     <Sonner
       theme={theme as ToasterProps['theme']}
-      className="toaster group z-0"
+      className="toaster group z-[99999]"
       toastOptions={{
         classNames: {
           toast:


### PR DESCRIPTION
## Description

This PR fixes an issue with toast notification layering that emerged from PR #344. While the previous fix prevented toasts from blocking the Pera Connect modal's launch button, it caused toasts to display behind our application's modal overlays.

## Details
- Optimize `Toaster` component's `z-index` to work with multiple overlay scenarios:
  - Set `z-index` to `99999` to display above app modals (`z-index: 50`)
  - Position below Pera Connect modal (`z-index: 999999`)
  - Fix regression where toasts were hidden behind overlay screens
- Maintains fix from #344 while ensuring toasts remain visible above app modals