### PR TITLE
fix(ui): maintain validator ID relationships in combined queries

### DIFF
--- a/ui/src/hooks/useValidators.ts
+++ b/ui/src/hooks/useValidators.ts
@@ -104,17 +104,24 @@ export function useValidators(): {
     const result: Validator[] = []
 
     for (let i = 0; i < validatorIds.length; i++) {
-      const config = configQueries.data[i]
-      const state = stateQueries.data[i]
-      const pools = poolsQueries.data[i]
-      const nodePoolAssignment = nodePoolAssignmentQueries.data[i]
-      const metrics = queuedMetricsQueries.data[i]
+      const validatorId = validatorIds[i]
+
+      // Find the data for this validator ID in each query result
+      const config = queryClient.getQueryData(validatorConfigQueryOptions(validatorId).queryKey)
+      const state = queryClient.getQueryData(validatorStateQueryOptions(validatorId).queryKey)
+      const pools = queryClient.getQueryData(validatorPoolsQueryOptions(validatorId).queryKey)
+      const nodePoolAssignment = queryClient.getQueryData(
+        validatorNodePoolAssignmentsQueryOptions(validatorId).queryKey,
+      )
+      const metrics = queryClient.getQueryData(
+        validatorMetricsQueryOptions(validatorId, queryClient).queryKey,
+      )
 
       if (!config || !state || !pools || !nodePoolAssignment) continue
 
       // Create base validator
       const baseValidator = createBaseValidator({
-        id: validatorIds[i],
+        id: validatorId,
         config,
         state,
         pools,


### PR DESCRIPTION
## Description

This PR fixes an issue where validator data could become mismatched when navigating from a validator details page back to the dashboard. The mismatch occurred because some validator data was already cached, causing the array positions in the queued query results to not align with validator IDs.

## Details

- Previously relied on array positions to match validator data with IDs
- When some data was cached (e.g., after viewing validator details), the array positions would not match the expected validator IDs
- Now using `queryClient.getQueryData()` with exact query keys to fetch data for each validator
- This ensures correct data matching regardless of cache state
- Removed dependency on array positions in query results
- Maintains correct validator ID relationships when combining data from multiple queries

The solution is simpler and more reliable as it works directly with Tanstack Query's cache mechanism instead of trying to maintain array position relationships across multiple query results.