### PR TITLE
fix(ui): fetch full NFD view and improve pool type safety

### DIFF
--- a/ui/src/api/contracts.ts
+++ b/ui/src/api/contracts.ts
@@ -81,14 +81,17 @@ export async function fetchValidatorPools(validatorId: number | bigint): Promise
   }
 
   // Transform raw pool data into LocalPoolInfo[]
-  return poolsData.map((poolInfo: [bigint, number, bigint], i: number) => ({
-    poolId: BigInt(i + 1),
-    poolAppId: poolInfo[0],
-    totalStakers: poolInfo[1],
-    totalAlgoStaked: poolInfo[2],
-    poolAddress: poolAddresses[i],
-    poolAlgodVersion: poolAlgodVersions[i],
-  }))
+  return poolsData.map(
+    (poolInfo: [bigint, number, bigint], i: number) =>
+      ({
+        poolId: BigInt(i + 1),
+        poolAppId: poolInfo[0],
+        totalStakers: poolInfo[1],
+        totalAlgoStaked: poolInfo[2],
+        poolAddress: poolAddresses[i],
+        algodVersion: poolAlgodVersions[i],
+      }) satisfies LocalPoolInfo,
+  )
 }
 
 export async function fetchValidatorNodePoolAssignments(

--- a/ui/src/hooks/useValidator.ts
+++ b/ui/src/hooks/useValidator.ts
@@ -53,7 +53,7 @@ export function useValidator(validatorId: number): Validator | undefined {
   const [nfdQuery] = useSuspenseQueries({
     queries: [
       ...(configQuery.data?.nfdForInfo && configQuery.data.nfdForInfo > 0
-        ? [nfdQueryOptions(Number(configQuery.data.nfdForInfo))]
+        ? [nfdQueryOptions(Number(configQuery.data.nfdForInfo), { view: 'full' })]
         : []),
     ],
   })


### PR DESCRIPTION
## Description

This PR addresses two issues in the validator details page: missing NFD user-defined properties and missing Algod version display. It enhances type safety for pool data mapping and ensures complete NFD data fetching.

## Details
- Add `view: 'full'` parameter to NFD query to include user-defined `bio` property
- Improve type safety in `fetchValidatorPools` using `satisfies` operator
- Fix property name from `poolAlgodVersion` to `algodVersion` to correctly display Algod version
- Ensure compile-time checking for `LocalPoolInfo` property mappings

Both issues were caught during pre-release testing and have been fixed before deployment to production.