### PR TITLE
fix(ui): remove incorrect pool max stake calculations

### DIFF
--- a/ui/src/components/ValidatorDetails/StakeProgressBar.tsx
+++ b/ui/src/components/ValidatorDetails/StakeProgressBar.tsx
@@ -1,0 +1,42 @@
+import { ProgressBar } from '@tremor/react'
+import { AlgoDisplayAmount } from '@/components/AlgoDisplayAmount'
+import { roundToFirstNonZeroDecimal } from '@/utils/format'
+
+interface StakeProgressBarProps {
+  currentAmount: bigint
+  maxAmount: bigint
+  className?: string
+}
+
+export function StakeProgressBar({ currentAmount, maxAmount, className }: StakeProgressBarProps) {
+  const currentAlgos = Number(currentAmount) / 1e6
+  const maxAlgos = Number(maxAmount) / 1e6
+  const percent = roundToFirstNonZeroDecimal((currentAlgos / maxAlgos) * 100)
+
+  return (
+    <div className={className}>
+      <p className="text-tremor-default text-stone-500 dark:text-stone-400 flex items-center justify-between">
+        <span>
+          <AlgoDisplayAmount
+            amount={currentAmount}
+            microalgos
+            maxLength={5}
+            compactPrecision={2}
+            mutedRemainder
+            className="font-mono text-foreground"
+          />{' '}
+          &bull; {percent}%
+        </span>
+        <AlgoDisplayAmount
+          amount={maxAmount}
+          microalgos
+          maxLength={5}
+          compactPrecision={2}
+          mutedRemainder
+          className="font-mono"
+        />
+      </p>
+      <ProgressBar value={percent} color="rose" className="mt-3" />
+    </div>
+  )
+}


### PR DESCRIPTION
## Description
This PR fixes how pool stake maximums are calculated and displayed. Previously, the validator's total stake limit was incorrectly divided evenly between all pools. Now each pool correctly shows its individual maximum based on either the validator's configured limit or the `maxAlgoPerPool` protocol constraint.

## Details
- Remove logic that divided `maxAlgoPerValidator` evenly between pools
- Show each pool's true maximum capacity based on validator config or protocol constraint
- Maintain validator-wide stake limit using `maxAlgoPerValidator`
- Extract stake progress bar display logic into reusable `StakeProgressBar` component