### PR TITLE
feat(ui): add max stake per pool to validator configuration

### DIFF
--- a/ui/src/api/contracts.ts
+++ b/ui/src/api/contracts.ts
@@ -258,7 +258,7 @@ export async function addValidator(
     percentToValidator: Math.round(Number(values.percentToValidator) * 10000),
     validatorCommissionAddress: values.validatorCommissionAddress,
     minEntryStake: AlgoAmount.Algos(Number(values.minEntryStake)).microAlgos,
-    maxAlgoPerPool: 0n,
+    maxAlgoPerPool: AlgoAmount.Algos(Number(values.maxAlgoPerPool || 0) * 1_000_000).microAlgos,
     poolsPerNode: Number(values.poolsPerNode),
     sunsettingOn: 0n,
     sunsettingTo: 0n,

--- a/ui/src/components/AddValidatorForm.tsx
+++ b/ui/src/components/AddValidatorForm.tsx
@@ -1,3 +1,4 @@
+import { AlgoAmount } from '@algorandfoundation/algokit-utils/types/amount'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
@@ -105,6 +106,7 @@ export function AddValidatorForm({ constraints }: AddValidatorFormProps) {
       percentToValidator: validatorSchemas.percentToValidator(constraints),
       validatorCommissionAddress: validatorSchemas.validatorCommissionAddress(),
       minEntryStake: validatorSchemas.minEntryStake(constraints),
+      maxAlgoPerPool: validatorSchemas.maxAlgoPerPool(constraints),
       poolsPerNode: validatorSchemas.poolsPerNode(constraints),
     })
     .superRefine((data, ctx) => rewardTokenRefinement(data, ctx, rewardToken?.params.decimals))
@@ -130,6 +132,7 @@ export function AddValidatorForm({ constraints }: AddValidatorFormProps) {
       percentToValidator: '',
       validatorCommissionAddress: '',
       minEntryStake: '',
+      maxAlgoPerPool: '',
       poolsPerNode: '1',
     },
   })
@@ -554,6 +557,44 @@ export function AddValidatorForm({ constraints }: AddValidatorFormProps) {
                       </div>
                     </FormControl>
                     <FormMessage>{errors.minEntryStake?.message}</FormMessage>
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="maxAlgoPerPool"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel htmlFor="max-algo-per-pool-input">
+                      Max stake per pool
+                      <InfoPopover className={infoPopoverClassName} label="Max stake per pool">
+                        Maximum total stake allowed in a pool in millions of ALGO (e.g., 50 for 50M
+                        ALGO). Protocol maximum will be used if left blank.
+                      </InfoPopover>
+                    </FormLabel>
+                    <FormControl>
+                      <div className="relative">
+                        <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+                          <AlgoSymbol
+                            verticalOffset={1}
+                            className="text-muted-foreground"
+                            aria-hidden="true"
+                          />
+                        </div>
+                        <Input
+                          id="max-algo-per-pool-input"
+                          className="pl-7"
+                          placeholder="Enter millions (e.g., 50)"
+                          {...field}
+                        />
+                      </div>
+                    </FormControl>
+                    <FormDescription>
+                      Leave blank to use protocol maximum (
+                      {AlgoAmount.MicroAlgos(constraints.maxAlgoPerPool).algos / 1_000_000}M).
+                    </FormDescription>
+                    <FormMessage>{errors.maxAlgoPerPool?.message}</FormMessage>
                   </FormItem>
                 )}
               />

--- a/ui/src/components/ValidatorDetails/Details.tsx
+++ b/ui/src/components/ValidatorDetails/Details.tsx
@@ -13,10 +13,12 @@ import { EditNfdForInfo } from '@/components/ValidatorDetails/EditNfdForInfo'
 import { EditRewardPerPayout } from '@/components/ValidatorDetails/EditRewardPerPayout'
 import { EditSunsettingInfo } from '@/components/ValidatorDetails/EditSunsettingInfo'
 import { GatingType } from '@/constants/gating'
+import { Constraints } from '@/contracts/ValidatorRegistryClient'
 import { Validator } from '@/interfaces/validator'
 import { useRewardBalance } from '@/hooks/useRewardBalance'
 import { dayjs } from '@/utils/dayjs'
 import { ellipseAddressJsx } from '@/utils/ellipseAddress'
+import { calculateMaxAlgoPerPool } from '@/utils/contracts'
 import { ExplorerLink } from '@/utils/explorer'
 import { convertFromBaseUnits, formatAmount, formatAssetAmount } from '@/utils/format'
 import { getNfdAppFromViteEnvironment } from '@/utils/network/getNfdConfig'
@@ -25,13 +27,15 @@ const nfdAppUrl = getNfdAppFromViteEnvironment()
 
 interface DetailsProps {
   validator: Validator
+  constraints: Constraints
 }
 
-export function Details({ validator }: DetailsProps) {
+export function Details({ validator, constraints }: DetailsProps) {
   const { activeAddress } = useWallet()
   const isOwner = activeAddress === validator.config.owner
 
   const rewardBalanceQuery = useRewardBalance(validator)
+  const calculatedMaxAlgoPerPool = calculateMaxAlgoPerPool(validator, constraints)
 
   const renderRewardBalance = () => {
     if (rewardBalanceQuery.isLoading) {
@@ -246,20 +250,18 @@ export function Details({ validator }: DetailsProps) {
                 </dd>
               </div>
 
-              {validator.config.maxAlgoPerPool > 0n && (
-                <div className="py-4 grid grid-cols-[2fr_3fr] gap-4 xl:grid-cols-2">
-                  <dt className="text-sm font-medium leading-normal text-muted-foreground">
-                    Max Stake Per Pool
-                  </dt>
-                  <dd className="flex items-center justify-between gap-x-2 text-sm leading-normal">
-                    <AlgoDisplayAmount
-                      amount={validator.config.maxAlgoPerPool}
-                      microalgos
-                      className="font-mono"
-                    />
-                  </dd>
-                </div>
-              )}
+              <div className="py-4 grid grid-cols-[2fr_3fr] gap-4 xl:grid-cols-2">
+                <dt className="text-sm font-medium leading-normal text-muted-foreground">
+                  Max Stake Per Pool
+                </dt>
+                <dd className="flex items-center justify-between gap-x-2 text-sm leading-normal">
+                  <AlgoDisplayAmount
+                    amount={calculatedMaxAlgoPerPool}
+                    microalgos
+                    className="font-mono"
+                  />
+                </dd>
+              </div>
 
               <div className="py-4 grid grid-cols-[2fr_3fr] gap-4 xl:grid-cols-2">
                 <dt className="text-sm font-medium leading-normal text-muted-foreground">

--- a/ui/src/components/ValidatorDetails/Details.tsx
+++ b/ui/src/components/ValidatorDetails/Details.tsx
@@ -245,6 +245,22 @@ export function Details({ validator }: DetailsProps) {
                   />
                 </dd>
               </div>
+
+              {validator.config.maxAlgoPerPool > 0n && (
+                <div className="py-4 grid grid-cols-[2fr_3fr] gap-4 xl:grid-cols-2">
+                  <dt className="text-sm font-medium leading-normal text-muted-foreground">
+                    Max Stake Per Pool
+                  </dt>
+                  <dd className="flex items-center justify-between gap-x-2 text-sm leading-normal">
+                    <AlgoDisplayAmount
+                      amount={validator.config.maxAlgoPerPool}
+                      microalgos
+                      className="font-mono"
+                    />
+                  </dd>
+                </div>
+              )}
+
               <div className="py-4 grid grid-cols-[2fr_3fr] gap-4 xl:grid-cols-2">
                 <dt className="text-sm font-medium leading-normal text-muted-foreground">
                   Epoch Length

--- a/ui/src/components/ValidatorDetails/ValidatorDetails.tsx
+++ b/ui/src/components/ValidatorDetails/ValidatorDetails.tsx
@@ -201,7 +201,7 @@ export function ValidatorDetails({
       />
       <div className="grid gap-4 lg:grid-cols-3">
         <div>
-          <Details validator={validator} />
+          <Details validator={validator} constraints={constraints} />
         </div>
         <div className="space-y-4 lg:col-span-2">{renderStakingDetails()}</div>
       </div>

--- a/ui/src/interfaces/validator.ts
+++ b/ui/src/interfaces/validator.ts
@@ -13,7 +13,7 @@ export type EntryGatingAssets = [bigint, bigint, bigint, bigint]
 
 export type ValidatorConfigInput = Omit<
   ToStringTypes<ValidatorConfig>,
-  'id' | 'maxAlgoPerPool' | 'sunsettingOn' | 'sunsettingTo'
+  'id' | 'sunsettingOn' | 'sunsettingTo'
 >
 
 export interface LocalPoolInfo {

--- a/ui/src/utils/validation.ts
+++ b/ui/src/utils/validation.ts
@@ -197,6 +197,34 @@ export const validatorSchemas = {
         message: `Must be at least ${AlgoAmount.MicroAlgos(Number(constraints.minEntryStake)).algos} ALGO`,
       })
   },
+  maxAlgoPerPool: (constraints: Constraints) => {
+    return z
+      .string()
+      .refine((val) => val === '' || (!isNaN(Number(val)) && Number(val) > 0), {
+        message: 'Must be a positive number or empty',
+      })
+      .refine(
+        (val) => {
+          if (val === '') return true
+          const match = val.match(/^(\d+)$/)
+          return match !== null
+        },
+        {
+          message: 'Must be a whole number (no decimals)',
+        },
+      )
+      .refine(
+        (val) => {
+          if (val === '') return true
+          // Convert the input (in millions) to microAlgos for comparison
+          const inputMicroAlgos = AlgoAmount.Algos(Number(val) * 1_000_000).microAlgos
+          return inputMicroAlgos <= constraints.maxAlgoPerPool
+        },
+        {
+          message: `Cannot exceed ${Number(AlgoAmount.MicroAlgos(constraints.maxAlgoPerPool).algos) / 1_000_000}M ALGO (protocol maximum)`,
+        },
+      )
+  },
   poolsPerNode: (constraints: Constraints) => {
     return z
       .string()


### PR DESCRIPTION
## Description

This PR adds support for configuring the maximum stake per pool when creating a validator. The feature allows users to set a limit on how much ALGO can be staked in each pool, with the option to use the protocol maximum as a default.

## Details
- Added `maxAlgoPerPool` field to the validator creation form
- Implemented validation to ensure input is a whole number in millions of ALGO
- Updated the `addValidator` function to convert user input to microAlgos
- Added descriptions and tooltips to guide users on proper input format
- Added display of max stake per pool in the validator details page
- Ensured the field is only displayed when a value greater than zero is set