### PR TITLE
fix(ui): correct max stake per pool calculation logic

### DIFF
--- a/ui/src/utils/contracts.ts
+++ b/ui/src/utils/contracts.ts
@@ -15,6 +15,7 @@ import {
   ValidatorConfig,
   ValidatorCurState,
 } from '@/contracts/ValidatorRegistryClient'
+import { BigMath } from './bigint'
 
 /**
  * Process node pool assignment configuration data into an array with each node's available slot count
@@ -448,27 +449,17 @@ export function calculateMaxAvailableToStake(
  */
 export function calculateMaxAlgoPerPool(validator: Validator, constraints: Constraints): bigint {
   const numPools = validator.state.numPools
-
-  // When there are no pools yet, we should still display the configured or protocol max value
-  if (numPools === 0) {
-    // If validator has a custom limit, use that, otherwise use the protocol constraint
-    return validator.config.maxAlgoPerPool > 0n
+  const maxAlgoPerPool =
+    validator.config.maxAlgoPerPool > 0n
       ? validator.config.maxAlgoPerPool
       : constraints.maxAlgoPerPool
+
+  if (numPools === 0) {
+    return maxAlgoPerPool
   }
 
-  const hardMaxDividedBetweenPools = constraints.maxAlgoPerValidator / BigInt(numPools)
-
-  // If maxAlgoPerPool is 0, use the protocol constraint
-  // Otherwise, use the minimum of the validator's config and the hard max divided between pools
-  const maxMicroalgoPerPool =
-    validator.config.maxAlgoPerPool === 0n
-      ? hardMaxDividedBetweenPools
-      : hardMaxDividedBetweenPools < validator.config.maxAlgoPerPool
-        ? hardMaxDividedBetweenPools
-        : validator.config.maxAlgoPerPool
-
-  return maxMicroalgoPerPool
+  const hardMaxAlgoPerPool = constraints.maxAlgoPerValidator / BigInt(numPools)
+  return BigMath.min(hardMaxAlgoPerPool, maxAlgoPerPool)
 }
 
 /**

--- a/ui/src/utils/contracts.ts
+++ b/ui/src/utils/contracts.ts
@@ -4,18 +4,18 @@ import { fetchAccountAssetInformation, fetchAccountInformation } from '@/api/alg
 import { fetchNfd, fetchNfdSearch } from '@/api/nfd'
 import { GatingType } from '@/constants/gating'
 import { Indicator } from '@/constants/indicator'
-import { Nfd, NfdSearchV2Params } from '@/interfaces/nfd'
-import { StakerValidatorData } from '@/interfaces/staking'
-import { LocalPoolInfo, NodeInfo, PoolData, Validator } from '@/interfaces/validator'
-import { dayjs } from '@/utils/dayjs'
-import { convertToBaseUnits, roundToFirstNonZeroDecimal, roundToWholeAlgos } from '@/utils/format'
 import {
   Constraints,
   NodePoolAssignmentConfig,
   ValidatorConfig,
   ValidatorCurState,
 } from '@/contracts/ValidatorRegistryClient'
-import { BigMath } from './bigint'
+import { Nfd, NfdSearchV2Params } from '@/interfaces/nfd'
+import { StakerValidatorData } from '@/interfaces/staking'
+import { LocalPoolInfo, NodeInfo, PoolData, Validator } from '@/interfaces/validator'
+import { BigMath } from '@/utils/bigint'
+import { dayjs } from '@/utils/dayjs'
+import { convertToBaseUnits, roundToFirstNonZeroDecimal, roundToWholeAlgos } from '@/utils/format'
 
 /**
  * Process node pool assignment configuration data into an array with each node's available slot count


### PR DESCRIPTION
## Description

This PR fixes a critical bug in the max stake per pool calculation where the protocol's maximum per pool constraint (70M ALGO) was not being properly applied when no custom limit was configured. This resulted in displaying values that exceeded the protocol maximum.

## Details
- Fix calculation to correctly apply protocol constraints in all scenarios
- Refactor implementation to calculate the applicable maximum (custom or protocol) once upfront
- Simplify logic with early return when there are no pools
- Use `BigMath.min` to properly compare all relevant limits
- Rename variables for clarity and consistency
- Ensure displayed maximum stake per pool is always accurate and never exceeds protocol-defined limits