### PR TITLE
fix(ui): add buffer to max stake calculation

### DIFF
--- a/ui/src/components/AddStakeModal.tsx
+++ b/ui/src/components/AddStakeModal.tsx
@@ -133,7 +133,8 @@ export function AddStakeModal({
 
   const stakerMaximumStake = React.useMemo(() => {
     const estimatedFee = AlgoAmount.MicroAlgos(240_000).microAlgos
-    return BigMath.max(0n, availableBalance - mbrAmount - estimatedFee)
+    const buffer = AlgoAmount.MicroAlgos(260_000).microAlgos // Totaling 0.5 ALGO to cover fees
+    return BigMath.max(0n, availableBalance - mbrAmount - estimatedFee - buffer)
   }, [availableBalance, mbrAmount])
 
   const maximumStake = BigMath.min(


### PR DESCRIPTION
## Description

This PR fixes an issue where users experienced transaction failures when using the "Max" button in the Add Stake modal. The fix adds a buffer to the maximum stake calculation to ensure sufficient funds remain for transaction fees.

## Details
- Added a 0.26 ALGO buffer to the `stakerMaximumStake` calculation (totaling 0.5 ALGO when combined with the existing fee estimation)
- This ensures users always have enough funds to cover transaction fees, even in complex transaction groups
- The buffer is a negligible amount compared to stake amounts but prevents frustrating transaction failures
- Users reported that reducing the amount slightly allowed transactions to succeed, confirming that a small buffer is all that's needed