### PR TITLE
fix(ui): disable staking when first pool is full because of v1 findPoolForStaker bug

### DIFF
--- a/contracts/bootstrap/package.json
+++ b/contracts/bootstrap/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bootstrap",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "description": "",
     "main": "index.ts",
     "scripts": {

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reti-contracts",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "license": "MIT",
     "scripts": {
         "generate-client": "algokit generate client contracts/artifacts/ --language typescript  --output contracts/clients/{contract_name}Client.ts && ./update_contract_artifacts.sh",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reti-ui",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "type": "module",
   "engines": {

--- a/ui/src/components/ValidatorTable.tsx
+++ b/ui/src/components/ValidatorTable.tsx
@@ -60,6 +60,7 @@ import {
   calculateStakeSaturation,
   canManageValidator,
   isAddingPoolDisabled,
+  isFirstPoolFull,
   isStakingDisabled,
   isSunsetted,
   isSunsetting,
@@ -359,6 +360,7 @@ export function ValidatorTable({
       id: 'actions',
       cell: ({ row }) => {
         const validator = row.original
+        const firstPoolFull = isFirstPoolFull(validator, constraints)
         const stakingDisabled = isStakingDisabled(activeAddress, validator, constraints)
         const unstakingDisabled = isUnstakingDisabled(activeAddress, validator, stakesByValidator)
         const addingPoolDisabled = isAddingPoolDisabled(activeAddress, validator, constraints)
@@ -384,10 +386,11 @@ export function ValidatorTable({
             ) : (
               <Button
                 size="sm"
-                className={cn({ hidden: stakingDisabled })}
+                disabled={firstPoolFull || stakingDisabled}
                 onClick={() => setAddStakeValidator(validator)}
+                className="min-w-[70px]"
               >
-                Stake
+                {firstPoolFull ? 'Full' : 'Stake'}
               </Button>
             )}
             <DropdownMenu>

--- a/ui/src/utils/contracts.spec.ts
+++ b/ui/src/utils/contracts.spec.ts
@@ -201,6 +201,20 @@ describe('isStakingDisabled', () => {
     }
     expect(isStakingDisabled(activeAddress, normalValidator, constraints)).toBe(false)
   })
+
+  it('should disable staking if the first pool is full', () => {
+    const validator = {
+      ...MOCK_VALIDATOR_1,
+      pools: [
+        {
+          ...MOCK_VALIDATOR_1.pools[0],
+          totalStakers: Number(constraints.maxStakersPerPool), // First pool is full
+        },
+        ...MOCK_VALIDATOR_1.pools.slice(1),
+      ],
+    }
+    expect(isStakingDisabled(activeAddress, validator, constraints)).toBe(true)
+  })
 })
 
 describe('isUnstakingDisabled', () => {

--- a/ui/src/utils/contracts.ts
+++ b/ui/src/utils/contracts.ts
@@ -201,6 +201,22 @@ export function calculateMaxStakers(validator: Validator, constraints?: Constrai
 }
 
 /**
+ * Check if the first pool of a validator is full
+ * @param {Validator} validator - Validator object
+ * @param {Constraints} constraints - Protocol constraints object
+ * @returns {boolean} Whether the first pool is full
+ */
+export function isFirstPoolFull(validator: Validator, constraints?: Constraints): boolean {
+  if (!constraints) {
+    return false
+  }
+
+  const maxStakersPerPool = constraints.maxStakersPerPool || 0n
+
+  return validator.pools.length > 0 && validator.pools[0].totalStakers >= Number(maxStakersPerPool)
+}
+
+/**
  * Check if staking is disabled based on the validator's state and protocol constraints
  * @param {string | null} activeAddress - Active wallet address
  * @param {Validator} validator - Validator object
@@ -226,7 +242,10 @@ export function isStakingDisabled(
   const maxStakers = maxStakersPerPool * BigInt(numPools)
   const maxStakersReached = totalStakers >= maxStakers
 
-  return noPools || maxStakersReached || maxStakeReached || isSunsetted(validator)
+  // Check if the first pool is full
+  const firstPoolFull = isFirstPoolFull(validator, constraints)
+
+  return noPools || maxStakersReached || maxStakeReached || isSunsetted(validator) || firstPoolFull
 }
 
 /**


### PR DESCRIPTION
- Added `isFirstPoolFull` utility function to check if the first pool of a validator is full
- Updated `isStakingDisabled` to account for the first pool being full
- Modified `ValidatorTable` to disable staking button and show 'Full' if the first pool is full
- Included tests for the new `isFirstPoolFull` logic