### PR TITLE
UI touchup

### DIFF
--- a/ui/src/components/ValidatorRewards.tsx
+++ b/ui/src/components/ValidatorRewards.tsx
@@ -1,0 +1,42 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { validatorMetricsQueryOptions } from '@/api/queries'
+import { AlgoDisplayAmount } from '@/components/AlgoDisplayAmount'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Validator } from '@/interfaces/validator'
+
+interface ValidatorRewardsProps {
+  validator: Validator
+}
+
+export function ValidatorRewards({ validator }: ValidatorRewardsProps) {
+  const queryClient = useQueryClient()
+  const metricsQuery = useQuery(validatorMetricsQueryOptions(validator.id, queryClient))
+
+  if (metricsQuery.isLoading) {
+    return (
+      <div className="flex items-center">
+        <Skeleton width={48} height={16} />
+      </div>
+    )
+  }
+
+  if (metricsQuery.isError) {
+    return (
+      <div className="flex items-center text-destructive">
+        <span className="text-sm">Error</span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex items-center">
+      <AlgoDisplayAmount
+        amount={metricsQuery.data?.rewardsBalance ?? 0n}
+        microalgos
+        trim={false}
+        maxLength={6}
+        compactPrecision={2}
+      />
+    </div>
+  )
+}

--- a/ui/src/components/ValidatorTable.tsx
+++ b/ui/src/components/ValidatorTable.tsx
@@ -70,7 +70,7 @@ import { dayjs } from '@/utils/dayjs'
 import { sendRewardTokensToPool, simulateEpoch } from '@/utils/development'
 import { ellipseAddressJsx } from '@/utils/ellipseAddress'
 import { formatAmount, formatAssetAmount } from '@/utils/format'
-import { globalFilterFn, sunsetFilter } from '@/utils/table'
+import { globalFilterFn, ineligibleFilter, MIN_ELIGIBLE_STAKE, sunsetFilter } from '@/utils/table'
 import { cn } from '@/utils/ui'
 import { ValidatorRewards } from '@/components/ValidatorRewards'
 
@@ -157,7 +157,10 @@ export function ValidatorTable({
   // Persistent column filters state
   const [columnFilters, setColumnFilters] = useLocalStorage<ColumnFiltersState>(
     'validator-column-filters',
-    [{ id: 'validator', value: false }],
+    [
+      { id: 'validator', value: false },
+      { id: 'stake', value: false },
+    ],
   )
 
   const handleColumnFiltersChange = (updaterOrValue: Updater<ColumnFiltersState>) => {
@@ -257,6 +260,7 @@ export function ValidatorTable({
     {
       id: 'stake',
       accessorFn: (row) => Number(row.state.totalAlgoStaked),
+      filterFn: ineligibleFilter,
       header: ({ column }) => <DataTableColumnHeader column={column} title="Stake" />,
       cell: ({ row }) => {
         const validator = row.original
@@ -539,6 +543,11 @@ export function ValidatorTable({
     .getPreFilteredRowModel()
     .rows.filter((row) => isSunsetted(row.original)).length
 
+  // Pre-filtered count of ineligible validators
+  const ineligibleCount = table
+    .getPreFilteredRowModel()
+    .rows.filter((row) => row.original.state.totalAlgoStaked < MIN_ELIGIBLE_STAKE).length
+
   return (
     <>
       <div>
@@ -546,21 +555,35 @@ export function ValidatorTable({
           <h2 className="flex items-center mb-2 text-lg font-semibold sm:flex-1 sm:my-1">
             Validators {isLoading && <Loading size="sm" inline className="ml-3" />}
           </h2>
-          <div
-            className={cn('flex items-center gap-x-2 h-7 sm:h-9 px-3 mb-3 sm:mb-0', {
-              hidden: sunsetCount === 0,
-            })}
-          >
-            <Checkbox
-              checked={(table.getColumn('validator')?.getFilterValue() as boolean) ?? false}
-              onCheckedChange={(checked) => table.getColumn('validator')?.setFilterValue(!!checked)}
-            />
-            <label
-              htmlFor="terms"
-              className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+          <div className="flex items-center gap-x-4 mb-3 sm:mb-0">
+            <div
+              className={cn('flex items-center gap-x-2 h-7 sm:h-9 px-3', {
+                hidden: sunsetCount === 0,
+              })}
             >
-              Show sunsetted ({sunsetCount})
-            </label>
+              <Checkbox
+                checked={(table.getColumn('validator')?.getFilterValue() as boolean) ?? false}
+                onCheckedChange={(checked) => table.getColumn('validator')?.setFilterValue(!!checked)}
+              />
+              <label
+                htmlFor="show-sunsetted"
+                className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+              >
+                Show sunsetted ({sunsetCount})
+              </label>
+            </div>
+            <div className="flex items-center gap-x-2 h-7 sm:h-9 px-3">
+              <Checkbox
+                checked={(table.getColumn('stake')?.getFilterValue() as boolean) ?? false}
+                onCheckedChange={(checked) => table.getColumn('stake')?.setFilterValue(!!checked)}
+              />
+              <label
+                htmlFor="show-ineligible"
+                className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+              >
+                Show ineligible ({ineligibleCount})
+              </label>
+            </div>
           </div>
           <div className="flex items-center gap-x-3 flex-wrap sm:flex-0">
             <div className="flex items-center gap-x-3 w-full sm:w-auto">

--- a/ui/src/components/ValidatorTable.tsx
+++ b/ui/src/components/ValidatorTable.tsx
@@ -563,7 +563,9 @@ export function ValidatorTable({
             >
               <Checkbox
                 checked={(table.getColumn('validator')?.getFilterValue() as boolean) ?? false}
-                onCheckedChange={(checked) => table.getColumn('validator')?.setFilterValue(!!checked)}
+                onCheckedChange={(checked) =>
+                  table.getColumn('validator')?.setFilterValue(!!checked)
+                }
               />
               <label
                 htmlFor="show-sunsetted"

--- a/ui/src/components/ValidatorTable.tsx
+++ b/ui/src/components/ValidatorTable.tsx
@@ -142,7 +142,7 @@ export function ValidatorTable({
   // Persistent column visibility state
   const [columnVisibility, setColumnVisibility] = useLocalStorage<VisibilityState>(
     'validator-columns',
-    {},
+    { 'pend. reward': false },
   )
 
   const handleColumnVisibilityChange = (updaterOrValue: Updater<VisibilityState>) => {
@@ -157,10 +157,7 @@ export function ValidatorTable({
   // Persistent column filters state
   const [columnFilters, setColumnFilters] = useLocalStorage<ColumnFiltersState>(
     'validator-column-filters',
-    [
-      { id: 'validator', value: false },
-      { id: 'stake', value: false },
-    ],
+    [{ id: 'validator', value: false }],
   )
 
   const handleColumnFiltersChange = (updaterOrValue: Updater<ColumnFiltersState>) => {

--- a/ui/src/components/ValidatorTable.tsx
+++ b/ui/src/components/ValidatorTable.tsx
@@ -72,6 +72,7 @@ import { ellipseAddressJsx } from '@/utils/ellipseAddress'
 import { formatAmount, formatAssetAmount } from '@/utils/format'
 import { globalFilterFn, sunsetFilter } from '@/utils/table'
 import { cn } from '@/utils/ui'
+import { ValidatorRewards } from '@/components/ValidatorRewards'
 
 interface ValidatorTableProps {
   validators: Validator[]
@@ -319,6 +320,19 @@ export function ValidatorTable({
             </span>
           </Tooltip>
         )
+      },
+    },
+    {
+      id: 'pend. reward',
+      accessorFn: (row) => row.rewardsBalance,
+      sortingFn: sortRewardsFn,
+      sortUndefined: -1,
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Pend. Rewards" />,
+      cell: ({ row }) => {
+        const validator = row.original
+        if (validator.state.numPools == 0) return '--'
+
+        return <ValidatorRewards validator={validator} />
       },
     },
     {

--- a/ui/src/utils/contracts.ts
+++ b/ui/src/utils/contracts.ts
@@ -689,7 +689,7 @@ export function calculateValidatorPoolMetrics(
     return oldest === 0n || data.balance === 0n || nextRound < oldest ? nextRound : oldest
   }, 0n)
 
-  const rewardsBalance = roundToWholeAlgos(totalBalances - totalAlgoStaked)
+  const rewardsBalance = totalBalances - totalAlgoStaked
   const roundsSinceLastPayout = oldestRound ? currentRound - oldestRound : undefined
 
   // Calculate APY weighted by the pool balances

--- a/ui/src/utils/contracts.ts
+++ b/ui/src/utils/contracts.ts
@@ -689,7 +689,7 @@ export function calculateValidatorPoolMetrics(
     return oldest === 0n || data.balance === 0n || nextRound < oldest ? nextRound : oldest
   }, 0n)
 
-  const rewardsBalance = totalBalances - totalAlgoStaked
+  const rewardsBalance = roundToWholeAlgos(totalBalances - totalAlgoStaked)
   const roundsSinceLastPayout = oldestRound ? currentRound - oldestRound : undefined
 
   // Calculate APY weighted by the pool balances

--- a/ui/src/utils/table.ts
+++ b/ui/src/utils/table.ts
@@ -2,6 +2,9 @@ import { FilterFn } from '@tanstack/react-table'
 import { Validator } from '@/interfaces/validator'
 import { isSunsetted } from '@/utils/contracts'
 
+// Minimum staking amount for eligible validators (30,000 ALGO in microALGOs)
+export const MIN_ELIGIBLE_STAKE = 30000n * 1000000n
+
 export const globalFilterFn: FilterFn<Validator> = (row, columnId, filterValue) => {
   if (filterValue === '') return true
 
@@ -45,4 +48,10 @@ export const sunsetFilter: FilterFn<Validator> = (row, columnId, showSunsetted) 
   const validator = row.original
   const isSunset = isSunsetted(validator)
   return showSunsetted ? true : !isSunset
+}
+
+export const ineligibleFilter: FilterFn<Validator> = (row, columnId, showIneligible) => {
+  const validator = row.original
+  const isIneligible = validator.state.totalAlgoStaked < MIN_ELIGIBLE_STAKE
+  return showIneligible ? true : !isIneligible
 }


### PR DESCRIPTION
feat(ui): refactor pool data processing and add validator rewards display
--
Refactor `processPoolData` to fetch data in parallel, improving efficiency and clarity.
Introduce `ValidatorRewards` component to display pending rewards in the `ValidatorTable`.

- Replaced sequential async calls in `processPoolData` with `Promise.all`
- Added `ValidatorRewards` component for reward display
- Updated `ValidatorTable` to include a "Pend. Rewards" column
- Simplified rewards balance calculation logic

feat(ui): add ineligible stake filter
--
Introduce a column filter for ineligible validators based on `MIN_ELIGIBLE_STAKE`. 
Added a new `ineligibleFilter` function to determine eligibility by staking amount and updated `ValidatorTable` to allow toggling visibility of ineligible validators.
Display the count of ineligible validators in the UI.