### PR TITLE
fix: testnet app id

### DIFF
--- a/nodemgr/internal/lib/algo/networks.go
+++ b/nodemgr/internal/lib/algo/networks.go
@@ -79,7 +79,7 @@ func getDefaults(network string) NetworkConfig {
 		cfg.NFDAPIUrl = "https://api.nf.domains"
 		cfg.NodeURL = "https://mainnet-api.4160.nodely.dev"
 	case "testnet":
-		cfg.RetiAppID = 734834614 // 4.0 algod avm11 (deployed 02/28/2025)
+		cfg.RetiAppID = 722930961 // 4.0 algod avm11 (deployed 02/28/2025)
 		cfg.NFDAPIUrl = "https://api.testnet.nf.domains"
 		cfg.NodeURL = "https://testnet-api.4160.nodely.dev"
 	case "betanet":

--- a/ui/.env.template
+++ b/ui/.env.template
@@ -60,7 +60,7 @@ VITE_NFD_APP_URL=https://app.testnet.nf.domains
 VITE_NFD_REGISTRY_APP_ID=84366825
 
 # Reti
-VITE_RETI_APP_ID=734834614
+VITE_RETI_APP_ID=722930961
 
 
 # ========================


### PR DESCRIPTION
## Description

Switch appid for testnet which changed apparently.

Old appid returned 0 validators which triggered.

