### PR TITLE
feat(ui): add institutional support page [prod]

### DIFF
--- a/ui/.prettierignore
+++ b/ui/.prettierignore
@@ -8,3 +8,5 @@ public
 .idea
 
 src/contracts
+
+src/routeTree.gen.ts

--- a/ui/src/components/MobileMenu.tsx
+++ b/ui/src/components/MobileMenu.tsx
@@ -1,7 +1,7 @@
 import { GitHubLogoIcon } from '@radix-ui/react-icons'
 import { Link } from '@tanstack/react-router'
 import { useWallet } from '@txnlab/use-wallet-react'
-import { Menu, Home, Monitor, Book, HandCoins } from 'lucide-react'
+import { Menu, Headset, Home, Monitor, Book, HandCoins } from 'lucide-react'
 import { Logo } from '@/components/Logo'
 import { ModeToggleMobile } from '@/components/ModeToggleMobile'
 import { Button } from '@/components/ui/button'
@@ -48,6 +48,16 @@ export function MobileMenu() {
               </Link>
             </SheetClose>
           )}
+
+          <SheetClose asChild>
+            <Link
+              to="/institutional-support"
+              className="flex items-center gap-4 px-2.5 text-muted-foreground hover:text-foreground [&.active]:text-foreground"
+            >
+              <Headset className="h-5 w-5" />
+              Institutional Support
+            </Link>
+          </SheetClose>
 
           {isTestnet && (
             <SheetClose asChild>

--- a/ui/src/components/Navigation.tsx
+++ b/ui/src/components/Navigation.tsx
@@ -24,6 +24,13 @@ export function Navigation() {
         </Link>
       )}
 
+      <Link
+        to="/institutional-support"
+        className="text-muted-foreground transition-colors hover:text-foreground [&.active]:text-foreground"
+      >
+        Institutional Support
+      </Link>
+
       <a
         href="https://txnlab.gitbook.io/reti-open-pooling"
         target="_blank"

--- a/ui/src/routeTree.gen.ts
+++ b/ui/src/routeTree.gen.ts
@@ -12,6 +12,7 @@
 
 import { Route as rootRoute } from './routes/__root'
 import { Route as ValidatorsImport } from './routes/validators'
+import { Route as InstitutionalSupportImport } from './routes/institutional-support'
 import { Route as AddImport } from './routes/add'
 import { Route as IndexImport } from './routes/index'
 import { Route as ValidatorsValidatorIdImport } from './routes/validators_.$validatorId'
@@ -21,6 +22,12 @@ import { Route as ValidatorsValidatorIdImport } from './routes/validators_.$vali
 const ValidatorsRoute = ValidatorsImport.update({
   id: '/validators',
   path: '/validators',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const InstitutionalSupportRoute = InstitutionalSupportImport.update({
+  id: '/institutional-support',
+  path: '/institutional-support',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -60,6 +67,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AddImport
       parentRoute: typeof rootRoute
     }
+    '/institutional-support': {
+      id: '/institutional-support'
+      path: '/institutional-support'
+      fullPath: '/institutional-support'
+      preLoaderRoute: typeof InstitutionalSupportImport
+      parentRoute: typeof rootRoute
+    }
     '/validators': {
       id: '/validators'
       path: '/validators'
@@ -82,6 +96,7 @@ declare module '@tanstack/react-router' {
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/add': typeof AddRoute
+  '/institutional-support': typeof InstitutionalSupportRoute
   '/validators': typeof ValidatorsRoute
   '/validators/$validatorId': typeof ValidatorsValidatorIdRoute
 }
@@ -89,6 +104,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/add': typeof AddRoute
+  '/institutional-support': typeof InstitutionalSupportRoute
   '/validators': typeof ValidatorsRoute
   '/validators/$validatorId': typeof ValidatorsValidatorIdRoute
 }
@@ -97,22 +113,40 @@ export interface FileRoutesById {
   __root__: typeof rootRoute
   '/': typeof IndexRoute
   '/add': typeof AddRoute
+  '/institutional-support': typeof InstitutionalSupportRoute
   '/validators': typeof ValidatorsRoute
   '/validators_/$validatorId': typeof ValidatorsValidatorIdRoute
 }
 
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/add' | '/validators' | '/validators/$validatorId'
+  fullPaths:
+    | '/'
+    | '/add'
+    | '/institutional-support'
+    | '/validators'
+    | '/validators/$validatorId'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/add' | '/validators' | '/validators/$validatorId'
-  id: '__root__' | '/' | '/add' | '/validators' | '/validators_/$validatorId'
+  to:
+    | '/'
+    | '/add'
+    | '/institutional-support'
+    | '/validators'
+    | '/validators/$validatorId'
+  id:
+    | '__root__'
+    | '/'
+    | '/add'
+    | '/institutional-support'
+    | '/validators'
+    | '/validators_/$validatorId'
   fileRoutesById: FileRoutesById
 }
 
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AddRoute: typeof AddRoute
+  InstitutionalSupportRoute: typeof InstitutionalSupportRoute
   ValidatorsRoute: typeof ValidatorsRoute
   ValidatorsValidatorIdRoute: typeof ValidatorsValidatorIdRoute
 }
@@ -120,6 +154,7 @@ export interface RootRouteChildren {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AddRoute: AddRoute,
+  InstitutionalSupportRoute: InstitutionalSupportRoute,
   ValidatorsRoute: ValidatorsRoute,
   ValidatorsValidatorIdRoute: ValidatorsValidatorIdRoute,
 }
@@ -138,6 +173,7 @@ export const routeTree = rootRoute
       "children": [
         "/",
         "/add",
+        "/institutional-support",
         "/validators",
         "/validators_/$validatorId"
       ]
@@ -147,6 +183,9 @@ export const routeTree = rootRoute
     },
     "/add": {
       "filePath": "add.tsx"
+    },
+    "/institutional-support": {
+      "filePath": "institutional-support.tsx"
     },
     "/validators": {
       "filePath": "validators.tsx"

--- a/ui/src/routes/institutional-support.tsx
+++ b/ui/src/routes/institutional-support.tsx
@@ -1,0 +1,337 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { CheckCircle } from 'lucide-react'
+import { Meta } from '@/components/Meta'
+import { PageHeader } from '@/components/PageHeader'
+import { PageMain } from '@/components/PageMain'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+
+export const Route = createFileRoute('/institutional-support')({
+  component: InstitutionalSupport,
+})
+
+function InstitutionalSupport() {
+  return (
+    <>
+      <Meta title="Institutional Support" />
+      <PageHeader
+        title="Institutional Support"
+        description="White-glove support for institutional validators"
+        separator
+      />
+      <PageMain>
+        <div className="space-y-8">
+          <div className="grid gap-8 lg:grid-cols-3">
+            {/* Onboarding Support */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-2xl">Onboarding Support</CardTitle>
+                <CardDescription>
+                  Get started with expert guidance and personalized setup assistance
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div className="space-y-4">
+                  <div className="space-y-3">
+                    <h4 className="font-semibold text-lg">Features</h4>
+                    <div className="space-y-3">
+                      <div className="flex items-start gap-3">
+                        <CheckCircle className="h-5 w-5 text-green-600 mt-0.5 flex-shrink-0" />
+                        <div>
+                          <div className="font-medium">Onboarding call</div>
+                          <div className="text-sm text-muted-foreground">
+                            1-hour walkthrough of protocol & node daemon
+                          </div>
+                        </div>
+                      </div>
+                      <div className="flex items-start gap-3">
+                        <CheckCircle className="h-5 w-5 text-green-600 mt-0.5 flex-shrink-0" />
+                        <div>
+                          <div className="font-medium">Configuration assistance</div>
+                          <div className="text-sm text-muted-foreground">
+                            Personalized recommendations & optimizations for pool / node setup
+                          </div>
+                        </div>
+                      </div>
+                      <div className="flex items-start gap-3">
+                        <CheckCircle className="h-5 w-5 text-green-600 mt-0.5 flex-shrink-0" />
+                        <div>
+                          <div className="font-medium">Monitoring</div>
+                          <div className="text-sm text-muted-foreground">
+                            Assistance setting up monitoring
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div className="pt-6 border-t">
+                  <div className="space-y-3">
+                    <div className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+                      Pricing
+                    </div>
+                    <div className="p-4 rounded-lg border">
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <div className="text-lg font-semibold">One-time Setup</div>
+                          <div className="text-sm text-muted-foreground">
+                            Complete onboarding package
+                          </div>
+                        </div>
+                        <div className="text-right">
+                          <div className="text-2xl font-bold">$499</div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Ongoing Support */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-2xl">Ongoing Support</CardTitle>
+                <CardDescription>
+                  Continuous support and guidance for your staking operations
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div className="space-y-4">
+                  <div className="space-y-3">
+                    <h4 className="font-semibold text-lg">Features</h4>
+                    <div className="space-y-3">
+                      <div className="flex items-start gap-3">
+                        <CheckCircle className="h-5 w-5 text-green-600 mt-0.5 flex-shrink-0" />
+                        <div>
+                          <div className="font-medium">
+                            Private support channel (Slack / Discord)
+                          </div>
+                          <div className="text-sm text-muted-foreground">
+                            Response within 8 hours
+                          </div>
+                        </div>
+                      </div>
+                      <div className="flex items-start gap-3">
+                        <CheckCircle className="h-5 w-5 text-green-600 mt-0.5 flex-shrink-0" />
+                        <div>
+                          <div className="font-medium">Managing pools & configurations</div>
+                          <div className="text-sm text-muted-foreground">
+                            Ongoing guidance managing pools
+                          </div>
+                        </div>
+                      </div>
+                      <div className="flex items-start gap-3">
+                        <CheckCircle className="h-5 w-5 text-green-600 mt-0.5 flex-shrink-0" />
+                        <div>
+                          <div className="font-medium">Network / protocol upgrades</div>
+                          <div className="text-sm text-muted-foreground">
+                            Custom guidance for any network or protocol changes
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div className="pt-6 border-t">
+                  <div className="space-y-4">
+                    <div className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+                      Pricing
+                    </div>
+                    <div className="space-y-3">
+                      <div className="p-4 rounded-lg border">
+                        <div className="flex items-center justify-between">
+                          <div>
+                            <div className="text-lg font-semibold">Monthly</div>
+                            <div className="text-sm text-muted-foreground">Billed monthly</div>
+                          </div>
+                          <div className="text-right">
+                            <div className="text-2xl font-bold">$499</div>
+                            <div className="text-sm text-muted-foreground">/month</div>
+                          </div>
+                        </div>
+                      </div>
+                      <div className="p-4 rounded-lg border">
+                        <div className="flex items-center justify-between">
+                          <div>
+                            <div className="text-lg font-semibold">Annual</div>
+                            <div className="text-sm text-muted-foreground">
+                              $416/month when billed annually
+                            </div>
+                          </div>
+                          <div className="text-right">
+                            <div className="text-2xl font-bold">$4,999</div>
+                            <div className="text-sm text-muted-foreground">/year</div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Managed Service */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-2xl">Managed Service</CardTitle>
+                <CardDescription>
+                  Complete hands-off staking solution with dedicated infrastructure
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div className="space-y-4">
+                  <div className="space-y-3">
+                    <h4 className="font-semibold text-lg">Features</h4>
+                    <div className="space-y-3">
+                      <div className="flex items-start gap-3">
+                        <CheckCircle className="h-5 w-5 text-green-600 mt-0.5 flex-shrink-0" />
+                        <div>
+                          <div className="font-medium">Dedicated node VM</div>
+                          <div className="text-sm text-muted-foreground">
+                            99.95% uptime guarantee with enterprise infrastructure
+                          </div>
+                        </div>
+                      </div>
+                      <div className="flex items-start gap-3">
+                        <CheckCircle className="h-5 w-5 text-green-600 mt-0.5 flex-shrink-0" />
+                        <div>
+                          <div className="font-medium">Dashboard with monitoring</div>
+                          <div className="text-sm text-muted-foreground">
+                            Real-time insights and alerts for your staking operations
+                          </div>
+                        </div>
+                      </div>
+                      <div className="flex items-start gap-3">
+                        <CheckCircle className="h-5 w-5 text-green-600 mt-0.5 flex-shrink-0" />
+                        <div>
+                          <div className="font-medium">Enterprise security</div>
+                          <div className="text-sm text-muted-foreground">
+                            Hands-off management without introducing custody risk
+                          </div>
+                        </div>
+                      </div>
+                      <div className="flex items-start gap-3">
+                        <CheckCircle className="h-5 w-5 text-green-600 mt-0.5 flex-shrink-0" />
+                        <div>
+                          <div className="font-medium">
+                            Private support channel (Slack / Discord)
+                          </div>
+                          <div className="text-sm text-muted-foreground">
+                            Response within 8 hours
+                          </div>
+                        </div>
+                      </div>
+                      <div className="flex items-start gap-3">
+                        <CheckCircle className="h-5 w-5 text-green-600 mt-0.5 flex-shrink-0" />
+                        <div>
+                          <div className="font-medium">Managing pools & configurations</div>
+                          <div className="text-sm text-muted-foreground">
+                            Full management of pools and configurations
+                          </div>
+                        </div>
+                      </div>
+                      <div className="flex items-start gap-3">
+                        <CheckCircle className="h-5 w-5 text-green-600 mt-0.5 flex-shrink-0" />
+                        <div>
+                          <div className="font-medium">Zero downtime upgrades</div>
+                          <div className="text-sm text-muted-foreground">
+                            Seamless updates without interrupting staking operations
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div className="pt-6 border-t">
+                  <div className="space-y-4">
+                    <div className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+                      Pricing
+                    </div>
+                    <div className="space-y-3">
+                      <div className="p-4 rounded-lg border">
+                        <div className="flex items-center justify-between">
+                          <div>
+                            <div className="text-lg font-semibold">Monthly</div>
+                            <div className="text-sm text-muted-foreground">Billed monthly</div>
+                          </div>
+                          <div className="text-right">
+                            <div className="text-2xl font-bold">$799</div>
+                            <div className="text-sm text-muted-foreground">/month</div>
+                          </div>
+                        </div>
+                      </div>
+                      <div className="p-4 rounded-lg border">
+                        <div className="flex items-center justify-between">
+                          <div>
+                            <div className="text-lg font-semibold">Annual</div>
+                            <div className="text-sm text-muted-foreground">
+                              $666/month when billed annually
+                            </div>
+                          </div>
+                          <div className="text-right">
+                            <div className="text-2xl font-bold">$7,999</div>
+                            <div className="text-sm text-muted-foreground">/year</div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Contact Information */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Get Started</CardTitle>
+              <CardDescription>
+                Contact us to discuss your requirements and schedule a consultation.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="grid gap-6 md:grid-cols-2">
+                <div className="flex items-center gap-3">
+                  <div className="h-10 w-10 bg-primary/10 rounded-lg flex items-center justify-center">
+                    <svg
+                      className="h-5 w-5 text-primary"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                      />
+                    </svg>
+                  </div>
+                  <div>
+                    <div className="text-sm text-muted-foreground">Email</div>
+                    <a
+                      href="mailto:reti@txnlab.dev?subject=Reti%20Institutional%20Support"
+                      className="font-semibold hover:text-primary transition-colors"
+                    >
+                      reti@txnlab.dev
+                    </a>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-3">
+                  <div className="h-10 w-10 bg-green-500/10 rounded-lg flex items-center justify-center">
+                    <CheckCircle className="h-5 w-5 text-green-600" />
+                  </div>
+                  <div>
+                    <div className="text-sm text-muted-foreground">Response Time</div>
+                    <div className="font-semibold">Within 24 hours</div>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </PageMain>
+    </>
+  )
+}


### PR DESCRIPTION
## Description

This PR adds a new institutional support page that provides detailed information about three service tiers for institutional validators. The page includes comprehensive feature lists, transparent pricing, and contact information to help institutional clients get started with Réti staking services.

## Details
- Added new `/institutional-support` route with dedicated page component
- Created three service tiers: Onboarding Support, Ongoing Support, and Managed Service
- Implemented responsive pricing cards with monthly/annual options
- Added navigation links in both desktop and mobile menus with headset icon
- Included contact information with email and response time details
- Updated route tree generation to include new institutional support route
- Maintained consistent design patterns with existing UI components
- Fixed CI prettier failures by excluding auto-generated routeTree.gen.ts from formatting

## Deployment Notes
This is a UI-only change that does not require a version bump or new release. The changes will be deployed to production without triggering new binaries or requiring node daemon upgrades.