### PR TITLE
Release v1.5.1

### DIFF
--- a/contracts/bootstrap/package.json
+++ b/contracts/bootstrap/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bootstrap",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "description": "",
     "main": "index.ts",
     "scripts": {

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reti-contracts",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "license": "MIT",
     "scripts": {
         "generate-client": "algokit generate client contracts/artifacts/ --language typescript  --output contracts/clients/{contract_name}Client.ts && ./update_contract_artifacts.sh",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reti-ui",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/ui/src/api/contracts.spec.ts
+++ b/ui/src/api/contracts.spec.ts
@@ -1,5 +1,5 @@
 import { HttpResponse, http } from 'msw'
-import { fetchPoolGlobalStates, processPoolData } from '@/api/contracts'
+import { fetchPoolGlobalStates, isPoolGlobalStateComplete, processPoolData } from '@/api/contracts'
 import { LocalPoolInfo } from '@/interfaces/validator'
 import {
   LAST_ROUND,
@@ -48,8 +48,8 @@ describe('fetchPoolGlobalStates', () => {
       lastPayout: 1000n,
       algodVer: '3.23.1 rel/stable [34171a94] : v0.8.2 [c58270f]',
     })
-    // A pool that has never paid out simply has no lastPayout key
-    expect(states.get(1020n)?.lastPayout).toBeUndefined()
+    // A pool whose node daemon has never reported has no algodVer, but still has lastPayout
+    expect(states.get(1020n)).toEqual({ lastPayout: 1080n })
   })
 
   it('warns and returns what it got when algod truncates the created app list', async () => {
@@ -109,10 +109,38 @@ describe('processPoolData', () => {
     expect(paths).toContain('/v2/applications/1011')
   })
 
-  it('leaves lastPayout undefined for a pool that has never paid out', async () => {
+  it('recovers a pool whose bulk entry came back without lastPayout', async () => {
+    const paths = trackRequests()
+
+    // Truthy, so a presence check would accept it and leave lastPayout undefined - which the
+    // Status column renders as "payouts stopped"
     const poolData = await processPoolData(poolFixture(1020n), { algodVer: '3.23.1' })
 
-    expect(poolData.lastPayout).toBeUndefined()
+    expect(poolData.lastPayout).toBe(1080n)
+    expect(paths).toContain('/v2/applications/1020')
+  })
+
+  it('does not re-read a complete entry that has no algodVer', async () => {
+    const paths = trackRequests()
+
+    const poolData = await processPoolData(poolFixture(1020n), { lastPayout: 1080n })
+
+    expect(poolData.lastPayout).toBe(1080n)
     expect(poolData.balance).toBe(AVAILABLE_BALANCE)
+    expect(paths.some((path) => path.startsWith('/v2/applications/'))).toBe(false)
+  })
+})
+
+describe('isPoolGlobalStateComplete', () => {
+  it('accepts an entry carrying lastPayout, with or without algodVer', () => {
+    expect(isPoolGlobalStateComplete({ lastPayout: 1000n })).toBe(true)
+    expect(isPoolGlobalStateComplete({ lastPayout: 0n, algodVer: '3.23.1' })).toBe(true)
+  })
+
+  it('rejects a missing or partially decoded entry', () => {
+    expect(isPoolGlobalStateComplete(undefined)).toBe(false)
+    expect(isPoolGlobalStateComplete({})).toBe(false)
+    // algodVer alone is not enough - lastPayout is what every pool is guaranteed to have
+    expect(isPoolGlobalStateComplete({ algodVer: '3.23.1' })).toBe(false)
   })
 })

--- a/ui/src/api/contracts.ts
+++ b/ui/src/api/contracts.ts
@@ -180,6 +180,24 @@ function decodePoolGlobalState(globalState: algosdk.modelsv2.TealKeyValue[] = []
 }
 
 /**
+ * Whether a pool's global state was read completely.
+ *
+ * `lastPayout` is written when the pool is created - `stakingPool.algo.ts` sets it to the
+ * creation round to establish the first epoch's baseline - so every pool has it, and all 283
+ * on MainNet do. Its absence therefore means the read didn't carry this pool's state, not that
+ * the pool is new, and the caller should recover it with a per-pool request.
+ *
+ * `algodVer` is deliberately not part of this test: it is only written once the node daemon
+ * reports in, so a pool can legitimately lack it (88 of those 283 do) and re-reading won't
+ * produce one.
+ */
+export function isPoolGlobalStateComplete(
+  state: PoolGlobalState | undefined,
+): state is PoolGlobalState {
+  return state?.lastPayout !== undefined
+}
+
+/**
  * Every staking pool's global state in a single request.
  *
  * Pools are created by the registry's own app account, so its `createdApps` carries the full
@@ -235,8 +253,9 @@ export function createBaseValidator({
 }
 
 /**
- * @param globalState - the pool's entry from {@link fetchPoolGlobalStates}. Omitted only when
- *   the bulk read didn't carry this pool, which costs one request to recover.
+ * @param globalState - the pool's entry from {@link fetchPoolGlobalStates}. Absent or
+ *   incomplete only when the bulk read didn't carry this pool, which costs one request to
+ *   recover.
  */
 export async function processPoolData(
   pool: LocalPoolInfo,
@@ -247,7 +266,10 @@ export async function processPoolData(
   // Define the promises for the async operations
   const balancePromise = fetchAccountBalance(poolAddress.toString(), true)
 
-  const globalStatePromise = globalState
+  // Tested on the field rather than on the entry: a pool whose state came back partial decodes
+  // to `{}`, which is truthy, and would otherwise skip the fallback and surface as a missing
+  // lastPayout - which the Status column renders as "payouts stopped".
+  const globalStatePromise = isPoolGlobalStateComplete(globalState)
     ? Promise.resolve(globalState)
     : fetchPoolGlobalState(pool.poolAppId)
 

--- a/ui/src/api/queries.ts
+++ b/ui/src/api/queries.ts
@@ -8,6 +8,7 @@ import {
   fetchAllValidatorData,
   fetchMbrAmounts,
   fetchPoolApy,
+  fetchPoolGlobalState,
   fetchPoolGlobalStates,
   fetchProtocolConstraints,
   fetchStakedInfoForPool,
@@ -154,6 +155,21 @@ export const poolGlobalStatesQueryOptions = queryOptions({
   refetchInterval: POOL_GLOBAL_STATES_REFETCH_INTERVAL,
   refetchOnWindowFocus: false,
 })
+
+/**
+ * One pool's global state, for recovering a pool the bulk read above didn't carry - algod caps
+ * the resources it returns per account, and the request can fail outright. Callers gate this on
+ * `isPoolGlobalStateComplete`, so on the normal path it never runs.
+ */
+export const poolGlobalStateQueryOptions = (poolAppId: bigint) =>
+  queryOptions({
+    queryKey: ['pool-global-state', String(poolAppId)],
+    queryFn: () => fetchPoolGlobalState(poolAppId),
+    enabled: !!poolAppId,
+    staleTime: METRICS_STALE_TIME,
+    refetchInterval: POOL_GLOBAL_STATES_REFETCH_INTERVAL,
+    refetchOnWindowFocus: false,
+  })
 
 const NO_POOL_GLOBAL_STATES: ReadonlyMap<bigint, PoolGlobalState> = new Map()
 

--- a/ui/src/components/ValidatorDetails/StakingPoolInfo.tsx
+++ b/ui/src/components/ValidatorDetails/StakingPoolInfo.tsx
@@ -1,7 +1,12 @@
 import { useQuery } from '@tanstack/react-query'
 import { ProgressBar } from '@tremor/react'
 import { Copy } from 'lucide-react'
-import { nfdLookupQueryOptions, poolGlobalStatesQueryOptions } from '@/api/queries'
+import { isPoolGlobalStateComplete } from '@/api/contracts'
+import {
+  nfdLookupQueryOptions,
+  poolGlobalStateQueryOptions,
+  poolGlobalStatesQueryOptions,
+} from '@/api/queries'
 import { AlgoDisplayAmount } from '@/components/AlgoDisplayAmount'
 import { Loading } from '@/components/Loading'
 import { NfdDisplay } from '@/components/NfdDisplay'
@@ -38,9 +43,21 @@ export function StakingPoolInfo({
   // Not stored in the validator box. Comes from the same bulk read of every pool's global
   // state that the dashboard's metrics use, so getting here is normally a cache hit.
   const poolGlobalStatesQuery = useQuery(poolGlobalStatesQueryOptions)
-  const algodVersion = poolInfo
-    ? poolGlobalStatesQuery.data?.get(poolInfo.poolAppId)?.algodVer
-    : undefined
+  const bulkPoolState = poolInfo ? poolGlobalStatesQuery.data?.get(poolInfo.poolAppId) : undefined
+
+  // The bulk read can come back without this pool, and can fail outright. Recover just this one
+  // rather than reporting the node as version "--" for the rest of the session. Gated on
+  // lastPayout, not on algodVer: a pool whose daemon has never reported has no algodVer to find,
+  // and re-reading it every time would put back the per-pool request the bulk read removed.
+  const poolStateIncomplete =
+    !!poolInfo && !poolGlobalStatesQuery.isPending && !isPoolGlobalStateComplete(bulkPoolState)
+
+  const poolGlobalStateQuery = useQuery({
+    ...poolGlobalStateQueryOptions(poolInfo?.poolAppId ?? 0n),
+    enabled: poolStateIncomplete,
+  })
+
+  const algodVersion = (poolStateIncomplete ? poolGlobalStateQuery.data : bulkPoolState)?.algodVer
 
   const numPools = validator.state.numPools
   const maxStakePerPool = calculateMaxAlgoPerPool(validator, constraints)

--- a/ui/src/components/ValidatorStatus.tsx
+++ b/ui/src/components/ValidatorStatus.tsx
@@ -7,6 +7,7 @@ import { Indicator } from '@/constants/indicator'
 import { useBlockTime } from '@/hooks/useBlockTime'
 import { Validator } from '@/interfaces/validator'
 import { formatDuration } from '@/utils/dayjs'
+import { formatAmount } from '@/utils/format'
 
 interface ValidatorRewardsProps {
   validator: Validator
@@ -43,45 +44,43 @@ export function ValidatorStatus({ validator }: ValidatorRewardsProps) {
       </div>
     )
   }
-  const perfScore = Number(validator.perf)
-  let perfTooltip = `${perfScore * 100}%`
-  let perfIndicator = Indicator.Normal
-  if (perfScore >= 0.7) {
-    perfIndicator = Indicator.Normal
-  } else if (perfScore < 0.7) {
-    perfIndicator = Indicator.Watch
-  } else {
+  // Absence is checked directly rather than inferred from `Number(undefined)` being NaN:
+  // "Nodely has no row for this validator" and "this validator is performing badly" are
+  // different states, and a lookup that silently stops matching must not read as the latter.
+  const perfScore = validator.perf
+  let perfIndicator: Indicator
+  let perfTooltip: string
+  if (perfScore === undefined) {
     perfIndicator = Indicator.Error
     perfTooltip = 'Not active'
+  } else {
+    perfIndicator = perfScore >= 0.7 ? Indicator.Normal : Indicator.Watch
+    perfTooltip = `${formatAmount(perfScore * 100, { precision: 1 })}%`
   }
 
-  const roundsSinceLastPayout = Number(metricsQuery.data?.roundsSinceLastPayout ?? 0)
+  // `undefined` means no metrics for this validator; 0 means it paid out this round.
+  const roundsSinceLastPayout =
+    metricsQuery.data?.roundsSinceLastPayout === undefined
+      ? undefined
+      : Number(metricsQuery.data.roundsSinceLastPayout)
+
   let statusIndicator = Indicator.Normal
-  let statusTooltooltip = ''
-  if (!roundsSinceLastPayout || roundsSinceLastPayout >= 1200n) {
+  let statusTooltip = ''
+  if (roundsSinceLastPayout === undefined || roundsSinceLastPayout >= 1200) {
     statusIndicator = Indicator.Error
-    statusTooltooltip = `Payouts stopped, behind ${formatDuration(
-      Number(metricsQuery.data?.roundsSinceLastPayout ?? 0) * blockTime.ms,
+    statusTooltip = `Payouts stopped, behind ${formatDuration(
+      (roundsSinceLastPayout ?? 0) * blockTime.ms,
     )}`
-  } else if (roundsSinceLastPayout >= 210n) {
+  } else if (roundsSinceLastPayout >= 210) {
     statusIndicator = Indicator.Watch
-    statusTooltooltip = `Payouts behind ${formatDuration(
-      Number(metricsQuery.data?.roundsSinceLastPayout ?? 0) * blockTime.ms,
-    )}`
-  } else if (roundsSinceLastPayout < 21n) {
-    statusIndicator = Indicator.Normal
-    statusTooltooltip = ''
+    statusTooltip = `Payouts behind ${formatDuration(roundsSinceLastPayout * blockTime.ms)}`
   }
 
   return (
     <span className="flex items-center space-x-2">
       <PerfIndicator tooltipContent={perfTooltip} indicator={perfIndicator} showGreen={true} />
       <span className="h-5 w-px bg-gray-300 dark:bg-gray-700"></span>
-      <TrafficLight
-        tooltipContent={statusTooltooltip}
-        indicator={statusIndicator}
-        showGreen={true}
-      />
+      <TrafficLight tooltipContent={statusTooltip} indicator={statusIndicator} showGreen={true} />
     </span>
   )
 }

--- a/ui/src/hooks/useValidators.ts
+++ b/ui/src/hooks/useValidators.ts
@@ -13,6 +13,7 @@ import {
 import { GatingType } from '@/constants/gating'
 import { useQueuedQueries } from '@/hooks/useQueuedQueries'
 import { Validator } from '@/interfaces/validator'
+import { findValidatorPerf } from '@/utils/nodely'
 
 /**
  * Dedupes and sorts a list of ids, returning a referentially stable array while the
@@ -161,12 +162,7 @@ export function useValidators(): {
           baseValidator.nfd = nfd
         }
       }
-      if (nodelyPerfQuery.data && nodelyPerfQuery.data.data) {
-        const perfScore = nodelyPerfQuery.data.data.find(
-          (q) => q.validatorid === baseValidator.id.toString(),
-        )?.perf
-        baseValidator.perf = perfScore
-      }
+      baseValidator.perf = findValidatorPerf(nodelyPerfQuery.data?.data, baseValidator.id)
 
       // Add metrics if available
       const metrics = queuedMetricsQueries.data[i]

--- a/ui/src/interfaces/nodely.ts
+++ b/ui/src/interfaces/nodely.ts
@@ -3,19 +3,23 @@
 //   type: 'UInt64' | 'Int64' | 'String' | 'Float64'
 // }
 
+/**
+ * One row per staking pool. The `UInt64`/`Int64` columns arrive as bare JSON numbers, not
+ * quoted strings - see the endpoint's own `meta` block.
+ */
 export interface NodelyRetiPerfData {
-  validatorid: string
-  poolid: string
-  poolappid: string
+  validatorid: number
+  poolid: number
+  poolappid: number
   poolappaddr: string
-  rspan: string
-  rounds: string
+  rspan: number
+  rounds: number
   avgfp: number
-  votes: string
+  votes: number
   expSoftVotes: number
   perf: number
   fOnline: number
-  lastSVRnd: string
+  lastSVRnd: number
 }
 
 export interface NodelyRetiPerf {

--- a/ui/src/utils/nodely.spec.ts
+++ b/ui/src/utils/nodely.spec.ts
@@ -1,0 +1,69 @@
+import { NodelyRetiPerfData } from '@/interfaces/nodely'
+import { findValidatorPerf } from '@/utils/nodely'
+
+function perfRow(overrides: Partial<NodelyRetiPerfData>): NodelyRetiPerfData {
+  return {
+    validatorid: 1,
+    poolid: 1,
+    poolappid: 3094048303,
+    poolappaddr: 'CRTAUOE76O76I3WDS4FKYRWYSMBPMV4TRG4O5PZWIY7ZHIGQROREQY6F6Y',
+    rspan: 31000,
+    rounds: 31000,
+    avgfp: 3.44,
+    votes: 30998,
+    expSoftVotes: 31000,
+    perf: 1,
+    fOnline: 1,
+    lastSVRnd: 64254000,
+    ...overrides,
+  }
+}
+
+describe('findValidatorPerf', () => {
+  it('matches the numeric validatorid the API actually returns', () => {
+    const rows = [
+      perfRow({ validatorid: 147, perf: 0.99 }),
+      perfRow({ validatorid: 137, perf: 0.42 }),
+    ]
+
+    expect(findValidatorPerf(rows, 147)).toBe(0.99)
+    expect(findValidatorPerf(rows, 137)).toBe(0.42)
+  })
+
+  it('still matches when validatorid comes back as a quoted string', () => {
+    // Nodely has serialized its uint64 columns both ways; neither shape may silently miss.
+    const rows = [perfRow({ validatorid: '147' as unknown as number, perf: 0.99 })]
+
+    expect(findValidatorPerf(rows, 147)).toBe(0.99)
+  })
+
+  it('accepts a bigint validator id', () => {
+    const rows = [perfRow({ validatorid: 147, perf: 0.99 })]
+
+    expect(findValidatorPerf(rows, 147n)).toBe(0.99)
+  })
+
+  it('returns the first pool row for a multi-pool validator', () => {
+    const rows = [
+      perfRow({ validatorid: 9, poolid: 1, perf: 0.95 }),
+      perfRow({ validatorid: 9, poolid: 2, perf: 0.12 }),
+    ]
+
+    expect(findValidatorPerf(rows, 9)).toBe(0.95)
+  })
+
+  it('returns undefined when the validator has no row', () => {
+    expect(findValidatorPerf([perfRow({ validatorid: 147 })], 148)).toBeUndefined()
+  })
+
+  it('returns undefined for missing or empty data', () => {
+    expect(findValidatorPerf(undefined, 147)).toBeUndefined()
+    expect(findValidatorPerf([], 147)).toBeUndefined()
+  })
+
+  it('preserves a genuine zero score rather than reporting no data', () => {
+    const rows = [perfRow({ validatorid: 147, perf: 0 })]
+
+    expect(findValidatorPerf(rows, 147)).toBe(0)
+  })
+})

--- a/ui/src/utils/nodely.ts
+++ b/ui/src/utils/nodely.ts
@@ -1,0 +1,23 @@
+import { NodelyRetiPerfData } from '@/interfaces/nodely'
+
+/**
+ * Picks a validator's 24h voting performance score out of Nodely's per-pool rows.
+ *
+ * Nodely returns one row per staking pool; the first row for the validator wins, which is
+ * what the Status column has always shown.
+ *
+ * Both sides are coerced rather than compared strictly. Nodely serializes `validatorid` as
+ * a bare JSON number today, and a strict compare against a string id resolves to `undefined`
+ * for every validator - which the UI renders as a confident "Not active" rather than as a
+ * failure, so nothing surfaces the mismatch.
+ *
+ * @param rows - `data` from the `poolvotingperformance/24hr` response
+ * @param validatorId - the validator to look up
+ * @returns the score in the range 0-1, or `undefined` when Nodely has no row for it
+ */
+export function findValidatorPerf(
+  rows: NodelyRetiPerfData[] | undefined,
+  validatorId: number | bigint,
+): number | undefined {
+  return rows?.find((row) => Number(row.validatorid) === Number(validatorId))?.perf
+}

--- a/ui/src/utils/tests/fixtures/applications.ts
+++ b/ui/src/utils/tests/fixtures/applications.ts
@@ -41,6 +41,7 @@ function stakingPool(appId: number, globalState: TealKeyValue[]): Application {
 export const appFixtures: FixtureData = {
   '1010': stakingPool(1010, [bytesValue('algodVer', ALGOD_VERSION), uintValue('lastPayout', 1000)]),
   '1011': stakingPool(1011, [bytesValue('algodVer', ALGOD_VERSION), uintValue('lastPayout', 1050)]),
-  // No lastPayout: stands in for a pool that has never paid out
-  '1020': stakingPool(1020, [bytesValue('algodVer', ALGOD_VERSION)]),
+  // No algodVer: the node daemon has never reported one. Every pool has lastPayout from
+  // creation, so this - not a missing lastPayout - is what a never-updated pool looks like.
+  '1020': stakingPool(1020, [uintValue('lastPayout', 1080)]),
 }


### PR DESCRIPTION
Three UI bug fixes, released as v1.5.1. No contract or nodemgr changes.

## Every validator's Status column read "Not active"

Nodely serializes the uint64 columns of `poolvotingperformance/24hr` as bare JSON numbers, but the lookup compared `validatorid` strictly against a string, so `validator.perf` was `undefined` for all 56 validators the feed covers:

```ts
(q) => q.validatorid === baseValidator.id.toString()   // 147 === "147"
```

`interfaces/nodely.ts` declared those columns as `string`, which is what kept `tsc` quiet. The miss then presented as a measurement rather than as missing data, because the branch rendering "Not active" was only reachable via `NaN` — both `NaN >= 0.7` and `NaN < 0.7` are false.

The lookup moves to `findValidatorPerf`, which coerces both sides; the feed has flipped these columns between quoted strings and raw numbers once already. `ValidatorStatus` now tests for absence directly, so "Nodely has no row for this validator" and "this validator is performing badly" stop sharing a branch, and formats the tooltip through `formatAmount` — it was rendering `99.87096774193549%`.

Against the live feed: the old predicate matched 0 of 56 validators, the new one matches all 56 → 53 green, 3 yellow.

## Pool global state the bulk read didn't carry stayed missed

`d386587` collapsed per-pool state into one `accountInformation` read on the registry, which left two gaps:

- `processPoolData` fell back on the presence of the entry, not on what it held. A pool whose state came back partial decodes to `{}` — truthy — so it kept the empty entry and returned no `lastPayout`, which the Status column renders as "Payouts stopped".
- `algodVer` lost its fallback entirely. `StakingPoolInfo` reads it only from the bulk map, and the per-pool read inside the metrics query keeps `lastPayout` while discarding the `algodVer` it fetched. Any pool the map lacked reported its node version as `--` for the rest of the session.

Both now gate on `isPoolGlobalStateComplete`, which tests `lastPayout` rather than the field being displayed. `lastPayout` is written when the pool is created (`stakingPool.algo.ts` sets it to the creation round as the first epoch's baseline), so every pool has one and its absence can only mean an incomplete read. Gating on `algodVer` would have been wrong: it is only written once the node daemon reports in, and **88 of MainNet's 283 pools legitimately have none** — keying on it would re-read a third of all pools on every visit and still show `--`.

## Also

The `1020` test fixture claimed a missing `lastPayout` stood for "a pool that has never paid out", which the contract does not do. It now models the case that does occur — a pool whose daemon has never reported, so no `algodVer`.

## Testing

`ui` suite 200 → 206 tests; `typecheck`, `lint`, `prettier`, and `build` clean.

Both fixes were checked against their own regression: reverting the perf compare fails 4 of the 7 new `nodely.spec.ts` cases, and reverting the fallback condition fails "recovers a pool whose bulk entry came back without lastPayout" with `expected undefined to be 1080n`.

Not verified in a browser: the `algodVer` fallback only fires when algod truncates or the bulk query fails, which can't be reproduced against live MainNet. Its normal path — bulk hit, no extra request — is covered by the specs.
